### PR TITLE
fix: guard database wipe script

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ pnpm seed
 ## Wipe the database (local only)
 
 ```bash
-NODE_ENV=development pnpm wipe --confirm
+NODE_ENV=development pnpm wipe -- --confirm
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ pnpm seed
 ## Wipe the database (local only)
 
 ```bash
-pnpm wipe
+NODE_ENV=development pnpm wipe --confirm
 ```
 
 ---

--- a/prisma/wipe.ts
+++ b/prisma/wipe.ts
@@ -7,8 +7,8 @@ async function wipeDatabase(): Promise<void> {
     const models = [
       "savedStudent",
       "actionCompletion",
-      "userInterest",
       "student",
+      "employee",
       "company",
       "action",
       "interest",
@@ -31,7 +31,14 @@ async function wipeDatabase(): Promise<void> {
 }
 
 if (process.env.NODE_ENV !== "development") {
-  console.error("This script should only be run in development!");
+  console.error("Refusing to wipe: NODE_ENV must be development.");
+  process.exit(1);
+}
+
+if (!process.argv.includes("--confirm")) {
+  console.error(
+    "Refusing to wipe: pass --confirm to delete all database records."
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
Prevent the database wipe script from referencing the implicit user-interest join and require explicit confirmation before deleting data.

The model list now uses the real Employee model in dependency-safe order. The script only proceeds in development with `--confirm`, and README usage reflects both safeguards.