### PR TITLE
fix: fix student PATCH validation and optional interests

### DIFF
--- a/src/app/api/students/[code]/route.ts
+++ b/src/app/api/students/[code]/route.ts
@@ -62,7 +62,7 @@ export async function PATCH(req: NextRequest, props: StudentProps) {
 
   const safeParse = patchStudentSchema.safeParse(requestBody);
   if (!safeParse.success)
-    return NextResponse.json({ message: safeParse.error });
+    return NextResponse.json({ message: safeParse.error }, { status: 400 });
 
   const body = safeParse.data;
   const student = await prisma.student.update({

--- a/src/app/api/students/[code]/route.ts
+++ b/src/app/api/students/[code]/route.ts
@@ -1,20 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 
 import config from "@/config";
 import { completeAction } from "@/lib/completeAction";
 import prisma from "@/lib/prisma";
 import { isSaved } from "@/lib/savedStudents";
 import getServerSession from "@/services/getServerSession";
-
-const schema = z.object({
-  bio: z.string(),
-  linkedin: z.string(),
-  github: z.string(),
-  interests: z.array(z.string()),
-});
-
-const schemaPartial = schema.partial();
+import { patchStudentSchema } from "@/schemas/patchStudentSchema";
 
 interface StudentProps {
   params: Promise<{
@@ -67,12 +58,13 @@ export async function PATCH(req: NextRequest, props: StudentProps) {
   if (!session.student || session.student.code !== code)
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
-  const body = await req.json();
+  const requestBody = await req.json();
 
-  const safeParse = schemaPartial.safeParse(body);
+  const safeParse = patchStudentSchema.safeParse(requestBody);
   if (!safeParse.success)
     return NextResponse.json({ message: safeParse.error });
 
+  const body = safeParse.data;
   const student = await prisma.student.update({
     where: { code },
     data: {
@@ -89,14 +81,16 @@ export async function PATCH(req: NextRequest, props: StudentProps) {
     );
   }
 
-  await prisma.user.update({
-    where: { id: session.id },
-    data: {
-      interests: {
-        set: body.interests.map((interest: string) => ({ name: interest })),
+  if (body.interests) {
+    await prisma.user.update({
+      where: { id: session.id },
+      data: {
+        interests: {
+          set: body.interests.map((interest) => ({ name: interest })),
+        },
       },
-    },
-  });
+    });
+  }
 
   return NextResponse.json(student);
 }

--- a/src/schemas/patchStudentSchema.ts
+++ b/src/schemas/patchStudentSchema.ts
@@ -7,4 +7,7 @@ export const patchStudentSchema = z
     github: z.string(),
     interests: z.array(z.string()),
   })
-  .partial();
+  .partial()
+  .refine((body) => Object.keys(body).length > 0, {
+    message: "At least one field is required",
+  });

--- a/src/schemas/patchStudentSchema.ts
+++ b/src/schemas/patchStudentSchema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const patchStudentSchema = z
+  .object({
+    bio: z.string(),
+    linkedin: z.string(),
+    github: z.string(),
+    interests: z.array(z.string()),
+  })
+  .partial();


### PR DESCRIPTION
## Summary
- move student PATCH schema into `src/schemas`
- use parsed data for student and interest writes
- skip interest relation update when `interests` is omitted

## Verification
- `pnpm exec prettier --check src/app/api/students/[code]/route.ts src/schemas/patchStudentSchema.ts`
- schema regression assertions via `pnpm exec tsx -e`
- `pnpm exec tsc --noEmit` *(blocked by pre-existing unrelated repository errors)*
- targeted ESLint *(blocked by pre-existing circular ESLint config error)*