### PR TITLE
fix: align .env.example with runtime env keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,10 +9,9 @@ DATABASE_URL="postgresql://postgres:<password>@<your-host>.supabase.co:5432/post
 DIRECT_URL="postgresql://postgres:<password>@<your-host>.supabase.co:5432/postgres?sslmode=require"
 
 # Supabase project configuration (hosted)
-SUPABASE_URL="https://<your-host>.supabase.co"                          # service URL (server)
-SUPABASE_KEY="service_role_key_here"                                   # service role key (server-only)
 NEXT_PUBLIC_SUPABASE_URL="https://<your-host>.supabase.co"             # public URL (client/server)
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY="anon_key_here"                   # anon key (client/server SSR)
+NEXT_PUBLIC_SUPABASE_ANON_KEY="anon_key_here"                          # anon key (client/server SSR)
+SUPABASE_SERVICE_ROLE_KEY="service_role_key_here"                      # service role key (server-only)
 
 # Optional overrides for docker compose
 # SUPABASE_PUBLIC_URL="http://127.0.0.1:54321"

--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ cp .env.example .env
 ### Required values (hosted Supabase)
 
 - `NEXT_PUBLIC_SUPABASE_URL`
-- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
-- `SUPABASE_URL`
-- `SUPABASE_KEY` (service role)
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY` (service role)
 
 ### Storage setup (Supabase hosted)
 


### PR DESCRIPTION
## Summary
- replace outdated Supabase env aliases with keys read by application code
- remove unused `SUPABASE_URL` entry

## Verification
- `git diff --check`
- compared Supabase keys in `.env.example` against `process.env` references under `src`