### PR TITLE
fix: fix html lang and run accessibility pass

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,11 +33,17 @@ export default function RootLayout({
         <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
       </head>
       <body>
+        <a
+          href="#main-content"
+          className="bg-primary sr-only z-50 p-3 text-black focus:not-sr-only focus:fixed focus:left-2 focus:top-2"
+        >
+          Saltar para o conteúdo principal
+        </a>
         <AuthContextProvider>
           <InstallableContextProvider>
             <SkeletonTheme baseColor="#eaeaea" highlightColor="#bfbfbf">
               <Topbar />
-              <main>{children}</main>
+              <main id="main-content">{children}</main>
               <ToastContainer position="bottom-right" />
               <InstallPopUp />
             </SkeletonTheme>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,7 +35,7 @@ export default function RootLayout({
       <body>
         <a
           href="#main-content"
-          className="bg-primary sr-only z-50 p-3 text-black focus:not-sr-only focus:fixed focus:left-2 focus:top-2"
+          className="sr-only z-50 bg-primary p-3 text-black focus:not-sr-only focus:fixed focus:top-2 focus:left-2"
         >
           Saltar para o conteúdo principal
         </a>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="h-svh">
+    <html lang="pt" className="h-svh">
       <head>
         <link rel="preconnect" href="https://rsms.me/" />
         <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />

--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -25,15 +25,18 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({ className }) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   return (
-    <span
+    <button
+      type="button"
       className={`cursor-pointer transition-colors hover:text-primary ${
         isLoading && "text-primary"
       } ${className}`}
       onClick={handleDownload}
+      disabled={isLoading}
       title="Exportar para CSV"
+      aria-label="Exportar para CSV"
     >
       {isLoading ? <Spinner /> : <DownloadIcon />}
-    </span>
+    </button>
   );
 };
 

--- a/src/components/Faq/FaqQuestion/index.tsx
+++ b/src/components/Faq/FaqQuestion/index.tsx
@@ -22,6 +22,9 @@ const FaqQuestion: React.FC<FaqQuestionProps> = ({
   isOpen,
   onToggle,
 }) => {
+  const buttonId = `faq-question-${index}`;
+  const panelId = `faq-answer-${index}`;
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 30 }}
@@ -32,7 +35,10 @@ const FaqQuestion: React.FC<FaqQuestionProps> = ({
     >
       <button
         type="button"
+        id={buttonId}
         onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
         className="flex w-full items-center justify-between gap-6 px-6 py-6 text-left text-base font-semibold text-white transition-colors duration-200 sm:px-8 sm:py-8 sm:text-lg"
       >
         <span className="flex-1 text-xl leading-tight sm:text-2xl md:text-3xl">
@@ -44,6 +50,9 @@ const FaqQuestion: React.FC<FaqQuestionProps> = ({
         {isOpen && (
           <motion.div
             key="faq-answer"
+            id={panelId}
+            role="region"
+            aria-labelledby={buttonId}
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}

--- a/src/components/FileInput/index.tsx
+++ b/src/components/FileInput/index.tsx
@@ -32,18 +32,21 @@ const FileInput: React.FC<InputProps> = ({
   file,
   icon,
   onClear,
+  id,
   ...rest
 }) => {
-  const id = slugifyId(name);
+  const resolvedId = id || slugifyId(name) || undefined;
 
   return (
     <div className="flex w-full flex-col">
-      <label
-        className="mb-1 text-left text-sm font-normal text-white"
-        htmlFor={id}
-      >
-        {name}
-      </label>
+      {name && (
+        <label
+          className="mb-1 text-left text-sm font-normal text-white"
+          htmlFor={resolvedId}
+        >
+          {name}
+        </label>
+      )}
       <div
         className={`flex w-full flex-row items-center justify-center ${className}`}
       >
@@ -51,7 +54,7 @@ const FileInput: React.FC<InputProps> = ({
           type="file"
           name={name}
           disabled={disabled}
-          id={id}
+          id={resolvedId}
           placeholder={placeholder}
           accept={accept}
           hidden
@@ -60,7 +63,7 @@ const FileInput: React.FC<InputProps> = ({
         />
         <label
           className={`flex h-14 flex-1 cursor-pointer flex-row items-center border border-white/35 bg-[#141414] px-2 py-1 text-sm ${file ? "text-white" : "text-white/35"}`}
-          htmlFor={id}
+          htmlFor={resolvedId}
         >
           <span className="mr-2 min-w-min text-lg md:text-xl">
             {file ? icon : <UploadIcon />}

--- a/src/components/FileInput/index.tsx
+++ b/src/components/FileInput/index.tsx
@@ -6,6 +6,8 @@ import {
   MdFileUpload as UploadIcon,
 } from "react-icons/md";
 
+import slugifyId from "@/utils/slugifyId";
+
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   name: string;
   accept: string;
@@ -32,11 +34,13 @@ const FileInput: React.FC<InputProps> = ({
   onClear,
   ...rest
 }) => {
+  const id = slugifyId(name);
+
   return (
     <div className="flex w-full flex-col">
       <label
         className="mb-1 text-left text-sm font-normal text-white"
-        htmlFor={name}
+        htmlFor={id}
       >
         {name}
       </label>
@@ -47,7 +51,7 @@ const FileInput: React.FC<InputProps> = ({
           type="file"
           name={name}
           disabled={disabled}
-          id={name}
+          id={id}
           placeholder={placeholder}
           accept={accept}
           hidden
@@ -56,7 +60,7 @@ const FileInput: React.FC<InputProps> = ({
         />
         <label
           className={`flex h-14 flex-1 cursor-pointer flex-row items-center border border-white/35 bg-[#141414] px-2 py-1 text-sm ${file ? "text-white" : "text-white/35"}`}
-          htmlFor={name}
+          htmlFor={id}
         >
           <span className="mr-2 min-w-min text-lg md:text-xl">
             {file ? icon : <UploadIcon />}
@@ -67,13 +71,25 @@ const FileInput: React.FC<InputProps> = ({
           {file && (
             <>
               <button
-                onClick={() => window.open(file.preview, "_blank")}
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  window.open(file.preview, "_blank");
+                }}
+                aria-label={`Pré-visualizar ${file.name}`}
                 className="ml-auto rounded-md p-1 transition-colors hover:bg-white/10"
               >
                 <PreviewIcon />
               </button>
               <button
-                onClick={onClear}
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onClear();
+                }}
+                aria-label={`Remover ${file.name}`}
                 className="ml-2 rounded-md p-1 transition-colors hover:bg-red-500 hover:text-white"
               >
                 <TrashIcon />

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -20,25 +20,28 @@ const Input: React.FC<InputProps> = ({
   disabled,
   inputRef,
   type = "text",
+  id,
   ...rest
 }) => {
-  const id = slugifyId(name);
+  const resolvedId = id || slugifyId(name) || undefined;
 
   return (
     <div className="flex w-full flex-col">
-      <label
-        className={`mb-1 text-sm font-normal text-white ${
-          center ? "text-left" : ""
-        }`}
-        htmlFor={id}
-      >
-        {name}
-      </label>
+      {name && (
+        <label
+          className={`mb-1 text-sm font-normal text-white ${
+            center ? "text-left" : ""
+          }`}
+          htmlFor={resolvedId}
+        >
+          {name}
+        </label>
+      )}
       <input
         type={type}
         name={name}
         disabled={disabled}
-        id={id}
+        id={resolvedId}
         placeholder={placeholder}
         ref={inputRef}
         className={`h-14 w-full border border-white/35 bg-[#141414] px-2 py-1 text-sm text-white placeholder:text-white/50 focus:border-primary focus:ring-0 disabled:text-gray-600 ${className}`}

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import slugifyId from "@/utils/slugifyId";
+
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   name: string;
   center?: boolean;
@@ -20,13 +22,15 @@ const Input: React.FC<InputProps> = ({
   type = "text",
   ...rest
 }) => {
+  const id = slugifyId(name);
+
   return (
     <div className="flex w-full flex-col">
       <label
         className={`mb-1 text-sm font-normal text-white ${
           center ? "text-left" : ""
         }`}
-        htmlFor={name}
+        htmlFor={id}
       >
         {name}
       </label>
@@ -34,10 +38,10 @@ const Input: React.FC<InputProps> = ({
         type={type}
         name={name}
         disabled={disabled}
-        id={name}
+        id={id}
         placeholder={placeholder}
         ref={inputRef}
-        className={`h-14 w-full border border-white/35 bg-[#141414] px-2 py-1 text-sm text-white placeholder:text-white/35 focus:border-primary focus:ring-0 disabled:text-gray-600 ${className}`}
+        className={`h-14 w-full border border-white/35 bg-[#141414] px-2 py-1 text-sm text-white placeholder:text-white/50 focus:border-primary focus:ring-0 disabled:text-gray-600 ${className}`}
         {...rest}
       />
     </div>

--- a/src/components/InputSelect/index.tsx
+++ b/src/components/InputSelect/index.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import slugifyId from "@/utils/slugifyId";
+
 interface InputSelectProps
   extends React.SelectHTMLAttributes<HTMLSelectElement> {
   name: string;
@@ -21,19 +23,21 @@ const InputSelect: React.FC<InputSelectProps> = ({
   options,
   ...rest
 }) => {
+  const id = slugifyId(name);
+
   return (
     <div className="flex w-full flex-col">
       <label
         className={`mb-1 text-sm font-normal text-white ${
           center ? "text-left" : ""
         }`}
-        htmlFor={name}
+        htmlFor={id}
       >
         {name}
       </label>
       <select
         name={name}
-        id={name}
+        id={id}
         disabled={disabled}
         defaultValue={placeholder}
         ref={inputRef}

--- a/src/components/InputSelect/index.tsx
+++ b/src/components/InputSelect/index.tsx
@@ -21,23 +21,26 @@ const InputSelect: React.FC<InputSelectProps> = ({
   disabled,
   inputRef,
   options,
+  id,
   ...rest
 }) => {
-  const id = slugifyId(name);
+  const resolvedId = id || slugifyId(name) || undefined;
 
   return (
     <div className="flex w-full flex-col">
-      <label
-        className={`mb-1 text-sm font-normal text-white ${
-          center ? "text-left" : ""
-        }`}
-        htmlFor={id}
-      >
-        {name}
-      </label>
+      {name && (
+        <label
+          className={`mb-1 text-sm font-normal text-white ${
+            center ? "text-left" : ""
+          }`}
+          htmlFor={resolvedId}
+        >
+          {name}
+        </label>
+      )}
       <select
         name={name}
-        id={id}
+        id={resolvedId}
         disabled={disabled}
         defaultValue={placeholder}
         ref={inputRef}

--- a/src/components/InstallButton/index.tsx
+++ b/src/components/InstallButton/index.tsx
@@ -17,7 +17,11 @@ const InstallButton: React.FC<InstallButtonProps> = ({ className }) => {
 
   return (
     isInstallable && (
-      <button onClick={handleConfirm} className={className}>
+      <button
+        onClick={handleConfirm}
+        aria-label="Instalar aplicação"
+        className={className}
+      >
         {isMobile ? (
           <InstallPwaMobile className="text-xl" />
         ) : (

--- a/src/components/LogoutButton/index.tsx
+++ b/src/components/LogoutButton/index.tsx
@@ -33,6 +33,7 @@ const LogoutButton: React.FC = () => {
   return (
     <button
       onClick={handleClick}
+      aria-label="Terminar sessão"
       className="flex size-full items-center justify-center fill-white text-xl transition-colors hover:text-primary"
     >
       <BiLogOut />

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { Dispatch, SetStateAction } from "react";
+import React, { Dispatch, SetStateAction, useEffect, useRef } from "react";
 
 interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
   isVisible: boolean;
@@ -15,6 +15,27 @@ const Modal: React.FC<ModalProps> = ({
   className,
   ...rest
 }) => {
+  const dialogRef = useRef<HTMLElement>(null);
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isVisible) return;
+
+    previouslyFocusedElement.current =
+      document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsVisible(false);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocusedElement.current?.focus();
+    };
+  }, [isVisible, setIsVisible]);
+
   if (!isVisible) return null;
 
   return (
@@ -24,8 +45,12 @@ const Modal: React.FC<ModalProps> = ({
         onClick={() => setIsVisible(false)}
       ></div>
       <main
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        ref={dialogRef}
         className={
-          "fixed top-1/2 left-1/2 z-60 w-full -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-8 text-black md:w-3/4 " +
+          "fixed top-1/2 left-1/2 z-60 w-full -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-8 text-black outline-none md:w-3/4 " +
           className
         }
         {...rest}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -8,6 +8,9 @@ interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
 }
 
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 const Modal: React.FC<ModalProps> = ({
   isVisible,
   setIsVisible,
@@ -26,7 +29,33 @@ const Modal: React.FC<ModalProps> = ({
     dialogRef.current?.focus();
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsVisible(false);
+      if (e.key === "Escape") {
+        setIsVisible(false);
+        return;
+      }
+
+      if (e.key !== "Tab" || !dialogRef.current) return;
+
+      const focusable = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      );
+      if (focusable.length === 0) {
+        e.preventDefault();
+        dialogRef.current.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && (active === first || active === dialogRef.current)) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener("keydown", handleKeyDown);
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -9,7 +9,7 @@ interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  'a[href]:not([hidden]), button:not([disabled]):not([hidden]), textarea:not([disabled]):not([hidden]), input:not([disabled]):not([hidden]), select:not([disabled]):not([hidden]), [tabindex]:not([tabindex="-1"]):not([hidden])';
 
 const Modal: React.FC<ModalProps> = ({
   isVisible,

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -51,7 +51,7 @@ const Modal: React.FC<ModalProps> = ({
         ref={dialogRef}
         className={
           "fixed top-1/2 left-1/2 z-60 w-full -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-8 text-black outline-none md:w-3/4 " +
-          className
+          (className ?? "")
         }
         {...rest}
       >

--- a/src/components/Profile/ImportCvSection/index.tsx
+++ b/src/components/Profile/ImportCvSection/index.tsx
@@ -18,14 +18,15 @@ const ImportCvSection: React.FC<ImportCvSectionProps> = ({
       <label className="text-lg text-slate-700">Curriculum Vitae</label>
       <div className="flex items-center space-x-2 hover:cursor-pointer hover:text-primary">
         <ImportCv className="mb-2 size-6"></ImportCv>
-        <a
+        <button
+          type="button"
           onClick={() => document.getElementById("inputCv")?.click()}
           className="pl-2 underline"
         >
           {text}
 
-          <label id="lbl" className="ml-4 text-sm" htmlFor=""></label>
-        </a>
+          <span id="lbl" className="ml-4 text-sm"></span>
+        </button>
         <input
           id="inputCv"
           onChange={() => {

--- a/src/components/Profile/Input/index.tsx
+++ b/src/components/Profile/Input/index.tsx
@@ -2,6 +2,7 @@
 
 interface InputProps {
   name: string;
+  id?: string;
   placeholder?: string;
   className?: string;
   disabled?: boolean;
@@ -11,22 +12,27 @@ interface InputProps {
 
 const Input: React.FC<InputProps> = ({
   name,
+  id,
   placeholder,
   className,
   disabled,
   defaultValue,
   inputRef,
 }) => {
+  const resolvedId = id || name || undefined;
+
   return (
     <div className="flex w-full flex-col">
-      <label className="text-lg text-slate-700" htmlFor={name}>
-        {name}
-      </label>
+      {name && (
+        <label className="text-lg text-slate-700" htmlFor={resolvedId}>
+          {name}
+        </label>
+      )}
       <input
         type="text"
         name={name}
         disabled={disabled}
-        id={name}
+        id={resolvedId}
         placeholder={placeholder}
         defaultValue={defaultValue ?? undefined}
         ref={inputRef}

--- a/src/components/Profile/OpenCvSection/index.tsx
+++ b/src/components/Profile/OpenCvSection/index.tsx
@@ -26,12 +26,13 @@ const OpenCvSection: React.FC<OpenCvProps> = ({ student, text }) => {
       </div>
       <div className="flex items-center hover:cursor-pointer hover:text-primary">
         <OpenCv className="mb-1 size-5"></OpenCv>
-        <a
+        <button
+          type="button"
           onClick={() => handleCv(student)}
           className="cursor-pointer pl-2 underline"
         >
           {text}
-        </a>
+        </button>
       </div>
     </div>
   );

--- a/src/components/Profile/ProfileSection/index.tsx
+++ b/src/components/Profile/ProfileSection/index.tsx
@@ -314,8 +314,11 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
         isVisible={isModalVisible}
         setIsVisible={setIsModalVisible}
         className="flex flex-col items-center justify-center gap-8"
+        aria-labelledby="avatar-modal-title"
       >
-        <h1 className="text-3xl font-bold">Altera o teu Avatar</h1>
+        <h1 id="avatar-modal-title" className="text-3xl font-bold">
+          Altera o teu Avatar
+        </h1>
         <AvatarCropper {...{ imageSrc, setImageSrc, setCroppedAreaPixels }} />
         <PrimaryButton
           className="w-full py-2 text-xl"

--- a/src/components/Profile/ProfileSection/index.tsx
+++ b/src/components/Profile/ProfileSection/index.tsx
@@ -193,10 +193,16 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
           <>
             {/* NOME */}
             <div className="flex flex-col gap-1">
-              <label className="text-xs font-medium text-gray-100">Nome</label>
+              <label
+                className="text-xs font-medium text-gray-100"
+                htmlFor="profile-name"
+              >
+                Nome
+              </label>
               <div className="border border-white bg-transparent">
                 <Input
                   name=""
+                  id="profile-name"
                   defaultValue={student.name}
                   disabled={true}
                   className="w-full border-none bg-transparent px-3 py-2 text-gray-100 focus:ring-0"
@@ -206,10 +212,16 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
 
             {/* ANO */}
             <div className="flex flex-col gap-1">
-              <label className="text-xs font-medium text-gray-100">Ano</label>
+              <label
+                className="text-xs font-medium text-gray-100"
+                htmlFor="profile-year"
+              >
+                Ano
+              </label>
               <div className="border border-white bg-transparent">
                 <Input
                   name=""
+                  id="profile-year"
                   defaultValue={student.year}
                   disabled={true}
                   className="w-full border-none bg-transparent px-3 py-2 text-gray-100 focus:ring-0"
@@ -219,10 +231,16 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
 
             {/* EMAIL */}
             <div className="flex flex-col gap-1">
-              <label className="text-xs font-medium text-gray-100">Email</label>
+              <label
+                className="text-xs font-medium text-gray-100"
+                htmlFor="profile-email"
+              >
+                Email
+              </label>
               <div className="border border-white bg-transparent">
                 <Input
                   name=""
+                  id="profile-email"
                   defaultValue={student.user.email}
                   disabled={true}
                   className="w-full border-none bg-transparent px-3 py-2 text-gray-100 focus:ring-0"
@@ -236,10 +254,16 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
 
         {/* LINKEDIN */}
         <div className="flex flex-col gap-1">
-          <label className="text-xs font-medium text-gray-100">LinkedIn</label>
+          <label
+            className="text-xs font-medium text-gray-100"
+            htmlFor="profile-linkedin"
+          >
+            LinkedIn
+          </label>
           <div className="border border-white bg-transparent">
             <Input
               name=""
+              id="profile-linkedin"
               defaultValue={profile.linkedin}
               placeholder="https://www.linkedin.com/in/nome"
               inputRef={linkedinRef}
@@ -250,10 +274,16 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
 
         {/* GITHUB */}
         <div className="flex flex-col gap-1">
-          <label className="text-xs font-medium text-gray-100">Github</label>
+          <label
+            className="text-xs font-medium text-gray-100"
+            htmlFor="profile-github"
+          >
+            Github
+          </label>
           <div className="border border-white bg-transparent">
             <Input
               name=""
+              id="profile-github"
               defaultValue={profile.github}
               placeholder="https://github.com/example"
               inputRef={githubRef}

--- a/src/components/Profile/SettingsSection/index.tsx
+++ b/src/components/Profile/SettingsSection/index.tsx
@@ -244,8 +244,11 @@ const SettingsSection: React.FC<SettingsSectionProps> = ({
         isVisible={isModalVisible}
         setIsVisible={setIsModalVisible}
         className="flex flex-col items-center justify-center gap-8"
+        aria-labelledby="avatar-modal-title"
       >
-        <h1 className="text-3xl font-bold">Altera o teu Avatar</h1>
+        <h1 id="avatar-modal-title" className="text-3xl font-bold">
+          Altera o teu Avatar
+        </h1>
         <AvatarCropper {...{ imageSrc, setImageSrc, setCroppedAreaPixels }} />
         <PrimaryButton
           className="w-full py-2 text-xl"

--- a/src/components/QRCode/QRCodeButton/index.tsx
+++ b/src/components/QRCode/QRCodeButton/index.tsx
@@ -17,6 +17,7 @@ const QRCodeButton: React.FC<QRCodeButtonProps> = ({ user }) => {
   return (
     <>
       <button
+        type="button"
         onClick={() => setIsHidden(false)}
         aria-label="Ver QR code"
         className="flex size-6 items-center justify-center fill-white p-0.5 text-2xl transition-colors hover:text-primary"

--- a/src/components/QRCode/QRCodeButton/index.tsx
+++ b/src/components/QRCode/QRCodeButton/index.tsx
@@ -16,8 +16,12 @@ const QRCodeButton: React.FC<QRCodeButtonProps> = ({ user }) => {
 
   return (
     <>
-      <button className="flex size-6 items-center justify-center fill-white p-0.5 text-2xl transition-colors hover:text-primary">
-        <BsQrCodeScan onClick={() => setIsHidden(false)} size={20} />
+      <button
+        onClick={() => setIsHidden(false)}
+        aria-label="Ver QR code"
+        className="flex size-6 items-center justify-center fill-white p-0.5 text-2xl transition-colors hover:text-primary"
+      >
+        <BsQrCodeScan size={20} />
       </button>
 
       <QRCodeModal setHidden={setIsHidden} hidden={isHidden} user={user} />

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -9,10 +9,12 @@ interface SpinnerProps {
 
 const Spinner: FunctionComponent<SpinnerProps> = ({ className }) => {
   return (
-    <span
-      className={`flex flex-1 animate-spin justify-center text-xl ${className}`}
-    >
-      <CgSpinner />
+    <span role="status" className="inline-flex">
+      <CgSpinner
+        aria-hidden="true"
+        className={`flex flex-1 animate-spin justify-center text-xl ${className}`}
+      />
+      <span className="sr-only">A carregar…</span>
     </span>
   );
 };

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -12,7 +12,7 @@ const Spinner: FunctionComponent<SpinnerProps> = ({ className }) => {
     <span role="status" className="inline-flex">
       <CgSpinner
         aria-hidden="true"
-        className={`flex flex-1 animate-spin justify-center text-xl ${className}`}
+        className={`flex flex-1 animate-spin justify-center text-xl ${className ?? ""}`}
       />
       <span className="sr-only">A carregar…</span>
     </span>

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -21,24 +21,27 @@ const TextArea: React.FC<TextAreaProps> = ({
   disabled,
   maxLength,
   inputRef,
+  id,
   ...rest
 }) => {
-  const id = slugifyId(name);
+  const resolvedId = id || slugifyId(name) || undefined;
 
   return (
     <div className="flex w-full flex-col">
-      <label
-        className={`text-slate-700 md:text-lg ${
-          center ? "mb-4 text-center" : ""
-        }`}
-        htmlFor={id}
-      >
-        {name}
-      </label>
+      {name && (
+        <label
+          className={`text-slate-700 md:text-lg ${
+            center ? "mb-4 text-center" : ""
+          }`}
+          htmlFor={resolvedId}
+        >
+          {name}
+        </label>
+      )}
       <textarea
         name={name}
         disabled={disabled}
-        id={id}
+        id={resolvedId}
         placeholder={placeholder}
         ref={inputRef}
         maxLength={maxLength}

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import slugifyId from "@/utils/slugifyId";
+
 interface TextAreaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   name: string;
@@ -21,20 +23,22 @@ const TextArea: React.FC<TextAreaProps> = ({
   inputRef,
   ...rest
 }) => {
+  const id = slugifyId(name);
+
   return (
     <div className="flex w-full flex-col">
       <label
         className={`text-slate-700 md:text-lg ${
           center ? "mb-4 text-center" : ""
         }`}
-        htmlFor={name}
+        htmlFor={id}
       >
         {name}
       </label>
       <textarea
         name={name}
         disabled={disabled}
-        id={name}
+        id={id}
         placeholder={placeholder}
         ref={inputRef}
         maxLength={maxLength}

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -48,6 +48,7 @@ const TopBar: React.FC = () => {
           {!session.user ? (
             <Link
               href={isAuthPage ? "/" : "/login"}
+              aria-label="Iniciar sessão"
               className="z-20 flex size-full items-center justify-center fill-white text-2xl transition-colors hover:text-primary"
             >
               <LogIn />

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -48,7 +48,7 @@ const TopBar: React.FC = () => {
           {!session.user ? (
             <Link
               href={isAuthPage ? "/" : "/login"}
-              aria-label="Iniciar sessão"
+              aria-label={isAuthPage ? "Página inicial" : "Iniciar sessão"}
               className="z-20 flex size-full items-center justify-center fill-white text-2xl transition-colors hover:text-primary"
             >
               <LogIn />

--- a/src/components/TopBarLink/index.tsx
+++ b/src/components/TopBarLink/index.tsx
@@ -10,15 +10,13 @@ interface TopbarLinkProps {
 
 const TopbarLink: React.FC<TopbarLinkProps> = ({ href, children, onClick }) => {
   return (
-    <>
-      <Link
-        onClick={onClick}
-        href={href}
-        className="text-primary transition duration-100 ease-in-out"
-      >
-        <button>{children}</button>
-      </Link>
-    </>
+    <Link
+      onClick={onClick}
+      href={href}
+      className="text-primary transition duration-100 ease-in-out"
+    >
+      {children}
+    </Link>
   );
 };
 

--- a/src/utils/slugifyId.ts
+++ b/src/utils/slugifyId.ts
@@ -1,0 +1,13 @@
+const COMBINING_DIACRITICS = /[̀-ͯ]/g;
+
+export default function slugifyId(text: string): string {
+  return (
+    text
+      .normalize("NFD")
+      .replace(COMBINING_DIACRITICS, "")
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "field"
+  );
+}

--- a/src/utils/slugifyId.ts
+++ b/src/utils/slugifyId.ts
@@ -1,13 +1,11 @@
 const COMBINING_DIACRITICS = /[̀-ͯ]/g;
 
 export default function slugifyId(text: string): string {
-  return (
-    text
-      .normalize("NFD")
-      .replace(COMBINING_DIACRITICS, "")
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "") || "field"
-  );
+  return text
+    .normalize("NFD")
+    .replace(COMBINING_DIACRITICS, "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }


### PR DESCRIPTION
## Summary
- Set `<html lang>` to `pt` (was `en`) to match the site's Portuguese content
- Accessibility pass: keyboard navigation (unfocusable click handlers, misplaced handlers), form label/id association, dialog and accordion ARIA, icon-only button labels, skip-to-content link

Closes #141