### PR TITLE
refactor: centralize request validation in src/schemas

### DIFF
--- a/src/app/api/auth/password-reset/route.ts
+++ b/src/app/api/auth/password-reset/route.ts
@@ -1,18 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 
 import { reportError } from "@/lib/logger";
+import {
+  confirmResetSchema,
+  requestResetSchema,
+} from "@/schemas/passwordResetSchema";
 
 import { createClient } from "@supabase/supabase-js";
-
-const requestResetSchema = z.object({
-  email: z.string().email(),
-});
-
-const confirmResetSchema = z.object({
-  password: z.string().min(8),
-  code: z.string().min(1),
-});
 
 export async function POST(req: NextRequest) {
   try {

--- a/src/app/api/students/[code]/cv/route.ts
+++ b/src/app/api/students/[code]/cv/route.ts
@@ -1,17 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 
 import config from "@/config";
 import { completeAction } from "@/lib/completeAction";
 import prisma from "@/lib/prisma";
 import { isSaved } from "@/lib/savedStudents";
+import { cvUploadSchema } from "@/schemas/cvUploadSchema";
 import getServerSession from "@/services/getServerSession";
 import { createAdminClient } from "@/utils/supabase/admin";
-
-const schema = z.union([
-  z.object({ uploadId: z.string().uuid() }), // Firebase flow
-  z.object({ id: z.string().uuid() }), // Supabase flow
-]);
 
 interface StudentParams {
   params: Promise<{
@@ -74,7 +69,7 @@ export async function POST(req: NextRequest, props: StudentParams) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const body = await req.json();
-  const parsed = schema.safeParse(body);
+  const parsed = cvUploadSchema.safeParse(body);
   if (!parsed.success) return NextResponse.json(parsed.error, { status: 400 });
 
   if ("id" in parsed.data) {

--- a/src/app/api/students/[code]/cv/route.ts
+++ b/src/app/api/students/[code]/cv/route.ts
@@ -4,8 +4,8 @@ import config from "@/config";
 import { completeAction } from "@/lib/completeAction";
 import prisma from "@/lib/prisma";
 import { isSaved } from "@/lib/savedStudents";
-import { cvUploadSchema } from "@/schemas/cvUploadSchema";
 import getServerSession from "@/services/getServerSession";
+import { cvUploadSchema } from "@/schemas/cvUploadSchema";
 import { createAdminClient } from "@/utils/supabase/admin";
 
 interface StudentParams {

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,13 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 
 import prisma from "@/lib/prisma";
 import { errorResponse } from "@/services/apiResponse";
 import getServerSession from "@/services/getServerSession";
-
-const schema = z.object({
-  interests: z.array(z.string()),
-});
+import { userInterestsSchema } from "@/schemas/userInterestsSchema";
 
 export async function PATCH(req: NextRequest) {
   const session = await getServerSession();
@@ -15,8 +11,10 @@ export async function PATCH(req: NextRequest) {
 
   const body = await req.json();
 
-  const safeParse = schema.safeParse(body);
+  const safeParse = userInterestsSchema.safeParse(body);
   if (!safeParse.success) return errorResponse(safeParse.error, 400);
+
+  const { interests } = safeParse.data;
 
   // If employee, update interests for ALL employees in the company
   if (session.employee) {
@@ -32,9 +30,7 @@ export async function PATCH(req: NextRequest) {
           where: { id: employee.user.id },
           data: {
             interests: {
-              set: body.interests.map((interest: string) => ({
-                name: interest,
-              })),
+              set: interests.map((interest) => ({ name: interest })),
             },
           },
         })
@@ -49,7 +45,7 @@ export async function PATCH(req: NextRequest) {
     where: { id: session.id },
     data: {
       interests: {
-        set: body.interests.map((interest: string) => ({ name: interest })),
+        set: interests.map((interest) => ({ name: interest })),
       },
     },
   });

--- a/src/schemas/changePasswordSchema.ts
+++ b/src/schemas/changePasswordSchema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const changePasswordSchema = z.object({
-  email: z.string(),
-  password: z.string().min(6),
-  confirmPassword: z.string().min(6),
+  email: z.string().max(255),
+  password: z.string().min(6).max(72),
+  confirmPassword: z.string().min(6).max(72),
 });

--- a/src/schemas/cvUploadSchema.ts
+++ b/src/schemas/cvUploadSchema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const cvUploadSchema = z.union([
+  z.object({ uploadId: z.string().uuid() }), // Firebase flow
+  z.object({ id: z.string().uuid() }), // Supabase flow
+]);

--- a/src/schemas/employeeSignUpSchema.ts
+++ b/src/schemas/employeeSignUpSchema.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
 
 export const employeeSignUpSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8, "Password must be at least 8 characters"),
-  name: z.string().min(2, "Name is too short"),
+  email: z.string().email().max(255),
+  password: z.string().min(8, "Password must be at least 8 characters").max(72),
+  name: z.string().min(2, "Name is too short").max(100),
   linkedin: z
     .string()
     .trim()
     .url("Invalid LinkedIn URL")
+    .max(2048)
     .optional()
     .or(z.literal(""))
     .transform((v) => (v === "" ? undefined : v)),

--- a/src/schemas/passwordResetSchema.ts
+++ b/src/schemas/passwordResetSchema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const requestResetSchema = z.object({
+  email: z.string().email().max(255),
+});
+
+export const confirmResetSchema = z.object({
+  password: z.string().min(8).max(72),
+  code: z.string().min(1).max(2048),
+});

--- a/src/schemas/patchStudentSchema.ts
+++ b/src/schemas/patchStudentSchema.ts
@@ -2,10 +2,10 @@ import { z } from "zod";
 
 export const patchStudentSchema = z
   .object({
-    bio: z.string(),
-    linkedin: z.string(),
-    github: z.string(),
-    interests: z.array(z.string()),
+    bio: z.string().max(1000),
+    linkedin: z.string().max(2048),
+    github: z.string().max(2048),
+    interests: z.array(z.string().min(1).max(50)).max(50),
   })
   .partial()
   .refine((body) => Object.keys(body).length > 0, {

--- a/src/schemas/postCompanySchema.ts
+++ b/src/schemas/postCompanySchema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const postCompanySchema = z.object({
-  name: z.string(),
+  name: z.string().min(1).max(100),
   tier: z.enum(["DIAMOND", "GOLD", "SILVER", "BRONZE"]),
-  avatarUrl: z.url().optional(),
+  avatarUrl: z.url().max(2048).optional(),
 });

--- a/src/schemas/postStudentSchema.ts
+++ b/src/schemas/postStudentSchema.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
 export const postStudentSchema = z.object({
-  name: z.string(),
-  bio: z.string().optional(),
+  name: z.string().min(1).max(100),
+  bio: z.string().max(1000).optional(),
   year: z.enum([
     "1º Ano Licenciatura",
     "2º Ano Licenciatura",
@@ -10,10 +10,10 @@ export const postStudentSchema = z.object({
     "1º Ano Mestrado",
     "2º Ano Mestrado",
   ]),
-  interests: z.array(z.string()),
+  interests: z.array(z.string().min(1).max(50)).max(50),
   avatar: z.uuid().optional(),
   cv: z.uuid().optional(),
   // Supabase-based alternative fields
-  avatarUrl: z.url().optional(),
+  avatarUrl: z.url().max(2048).optional(),
   cvId: z.uuid().optional(),
 });

--- a/src/schemas/saveSchema.ts
+++ b/src/schemas/saveSchema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
 
 export const saveSchema = z.object({
-  token: z.string().optional(),
+  token: z.string().max(2048).optional(),
 });

--- a/src/schemas/saveStudentAdminSchema.ts
+++ b/src/schemas/saveStudentAdminSchema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
 export const saveStudentAdminSchema = z.object({
-  studentEmailNumber: z.string(),
-  companyId: z.string(),
+  studentEmailNumber: z.string().min(1).max(100),
+  companyId: z.string().min(1).max(191),
 });

--- a/src/schemas/signInSchema.ts
+++ b/src/schemas/signInSchema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
 export const signInSchema = z.object({
-  email: z.email(),
-  password: z.string(),
+  email: z.email().max(255),
+  password: z.string().max(72),
 });

--- a/src/schemas/signUpSchema.ts
+++ b/src/schemas/signUpSchema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const signUpSchema = z.object({
-  email: z.email(),
-  password: z.string().min(8),
+  email: z.email().max(255),
+  password: z.string().min(8).max(72),
   role: z.enum(["COMPANY"]).optional(),
 });

--- a/src/schemas/userInterestsSchema.ts
+++ b/src/schemas/userInterestsSchema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const userInterestsSchema = z.object({
+  interests: z.array(z.string().min(1).max(50)).max(50),
+});


### PR DESCRIPTION
## Summary
- Move the remaining inline `z.object()` validation (in `students/[code]/cv`, `user`, and `auth/password-reset` routes) into named schemas under `src/schemas/`, so every route now validates via a shared schema.
- Add `.max()` bounds to previously-unbounded free-text fields across all schemas (`name`, `bio`, `password`, tokens, URLs) to close a large-payload/storage-abuse vector.
close #127