### PR TITLE
refactor: validate env with zod and enable strict mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,17 @@ COPY --from=deps /app/package.json /app/pnpm-lock.yaml ./
 ARG NEXT_PUBLIC_SENTRY_DSN=""
 ARG SENTRY_ORG=""
 ARG SENTRY_PROJECT=""
+# Public (non-secret) Supabase values: Next.js inlines these into the
+# browser bundle at build time, so the builder stage needs them directly —
+# unlike JWT_SECRET/SUPABASE_SERVICE_ROLE_KEY, which stay runtime-only via
+# env_file (see docker-compose.app.yml).
+ARG NEXT_PUBLIC_SUPABASE_URL=""
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY=""
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 ENV SENTRY_ORG=$SENTRY_ORG
 ENV SENTRY_PROJECT=$SENTRY_PROJECT
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV NODE_OPTIONS="--max-old-space-size=2048"
 
 # Selective copy (smaller context)

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -16,6 +16,8 @@ services:
         NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
         SENTRY_ORG: ${SENTRY_ORG:-}
         SENTRY_PROJECT: ${SENTRY_PROJECT:-}
+        NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL:-}
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:-}
     container_name: fallstack-app
     restart: unless-stopped
     depends_on:

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-icons": "^5.5.0",
     "react-loading-skeleton": "^3.5.0",
     "react-zxing": "^2.1.0",
+    "server-only": "^0.0.1",
     "sharp": "^0.34.5",
     "swal": "^0.1.0",
     "sweetalert": "^2.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       react-zxing:
         specifier: ^2.1.0
         version: 2.1.0(react@18.3.1)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -5178,6 +5181,9 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -11805,6 +11811,8 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,8 +1,9 @@
+import { clientEnv } from "@/config/env.client";
 import { sanitizeSentryEvent, sanitizeSentryLog } from "@/lib/sentryPrivacy";
 
 import * as Sentry from "@sentry/nextjs";
 
-const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const dsn = clientEnv.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,8 +1,9 @@
+import { clientEnv } from "@/config/env.client";
 import { sanitizeSentryEvent, sanitizeSentryLog } from "@/lib/sentryPrivacy";
 
 import * as Sentry from "@sentry/nextjs";
 
-const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const dsn = clientEnv.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn,

--- a/src/app/api/auth/password-reset/route.ts
+++ b/src/app/api/auth/password-reset/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
+import { serverEnv } from "@/config/env.server";
 import { reportError } from "@/lib/logger";
 
 import { createClient } from "@supabase/supabase-js";
@@ -20,8 +21,8 @@ export async function POST(req: NextRequest) {
     // Use the anon key for sending the password reset email
     // This ensures the flow behaves like a client-side request and avoids some security scanner issues
     const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+      serverEnv.NEXT_PUBLIC_SUPABASE_URL,
+      serverEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY
     );
 
     // Check if this is a password reset request (has email)

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
   if (!session)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  if (session.role !== "EMPLOYEE")
+  if (session.role !== "EMPLOYEE" || !session.employee?.company)
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const saves = await prisma.savedStudent.findMany({

--- a/src/app/api/saved/route.ts
+++ b/src/app/api/saved/route.ts
@@ -25,13 +25,14 @@ export async function POST(req: NextRequest) {
 
   const { token } = safeParse.data;
 
-  let studentCode = token;
-  if (token) {
-    const decoded = verifyJwt(token) as unknown as { code: string } | null;
-    if (!decoded)
-      return NextResponse.json({ error: "Invalid token" }, { status: 400 });
-    else studentCode = decoded.code;
-  }
+  if (!token)
+    return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+
+  const decoded = verifyJwt(token) as unknown as { code?: string } | null;
+  if (!decoded?.code)
+    return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+
+  const studentCode = decoded.code;
 
   // check if student exists
   const student = await prisma.student.findUnique({

--- a/src/components/Companies/CompanyPageSection/index.tsx
+++ b/src/components/Companies/CompanyPageSection/index.tsx
@@ -17,10 +17,13 @@ const CompanyPageSection: React.FC<CompanyPageSectionProps> = ({
 }) => {
   const company = findCompanyByName(companyName);
 
-  if (!company || !company.props.modalInformation) return null;
+  if (!company) return null;
 
   const { props: companyProps, tier } = company;
   const { modalInformation } = companyProps;
+
+  if (!modalInformation) return null;
+
   const interests = companyProps.interests || [];
 
   return (

--- a/src/components/PassSection/PassMenuContent.tsx
+++ b/src/components/PassSection/PassMenuContent.tsx
@@ -56,7 +56,7 @@ const PassMenuContent: React.FC<PassMenuContentProps> = ({ user, code }) => {
       </p>
       {/* New styled card design */}
       <StyledPassCard
-        name={user.student?.name}
+        name={user.student?.name ?? ""}
         qrValue={qrToken}
         loading={loading}
         code={user.student?.code}

--- a/src/components/QRCode/QRCodeScanner/index.tsx
+++ b/src/components/QRCode/QRCodeScanner/index.tsx
@@ -67,7 +67,7 @@ const QRCodeScanner: React.FC<QRCodeScannerProps> = ({ handleScan }) => {
         </div>
       )}
       <video
-        ref={ref}
+        ref={ref as React.RefObject<HTMLVideoElement>}
         className="rounded-lg"
         style={{ visibility: loading ? "hidden" : "visible" }}
       />

--- a/src/config/env.client.ts
+++ b/src/config/env.client.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+// Vars read here as `process.env.NEXT_PUBLIC_*` (literal member access) so
+// Next.js can statically inline them into the browser bundle. Safe to import
+// from both Client and Server Components.
+const clientEnvSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
+  NEXT_PUBLIC_BASE_URL: z.string().url().default("http://localhost:3000/api"),
+  NEXT_PUBLIC_SENTRY_DSN: z.string().url().optional(),
+});
+
+function parseClientEnv() {
+  const result = clientEnvSchema.safeParse({
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
+    NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  });
+
+  if (!result.success) {
+    throw new Error(
+      `Invalid client environment variables:\n${result.error.issues
+        .map((issue) => `  ${issue.path.join(".")}: ${issue.message}`)
+        .join("\n")}`
+    );
+  }
+
+  return result.data;
+}
+
+export const clientEnv = parseClientEnv();

--- a/src/config/env.client.ts
+++ b/src/config/env.client.ts
@@ -7,7 +7,13 @@ const clientEnvSchema = z.object({
   NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
   NEXT_PUBLIC_BASE_URL: z.string().url().default("http://localhost:3000/api"),
-  NEXT_PUBLIC_SENTRY_DSN: z.string().url().optional(),
+  // Empty string (the Dockerfile's `ARG NEXT_PUBLIC_SENTRY_DSN=""` default
+  // when no build arg is supplied) means "unset", same as undefined — not
+  // an invalid URL.
+  NEXT_PUBLIC_SENTRY_DSN: z.preprocess(
+    (value) => (value === "" ? undefined : value),
+    z.string().url().optional()
+  ),
 });
 
 function parseClientEnv() {
@@ -29,4 +35,9 @@ function parseClientEnv() {
   return result.data;
 }
 
+// These are all `NEXT_PUBLIC_*` vars: Next.js inlines them into the browser
+// bundle at build time, so unlike `serverEnv` they must stay eagerly
+// validated here — the Docker builder stage needs to actually receive them
+// as build args (see Dockerfile/docker-compose.app.yml), not have this
+// deferred to request time.
 export const clientEnv = parseClientEnv();

--- a/src/config/env.server.ts
+++ b/src/config/env.server.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import { z } from "zod";
+
+// Secrets and server-only config. Reads the full `process.env` (the real
+// runtime environment on the server, unlike the client bundle) so this
+// module never needs to enumerate the passthrough NODE_ENV/LOG_LEVEL vars
+// by hand. Importing this from client code is a build-time error.
+const serverEnvSchema = z.object({
+  NODE_ENV: z
+    .enum(["development", "test", "production"])
+    .default("development"),
+  JWT_SECRET: z
+    .string()
+    .min(32, "JWT_SECRET must be at least 32 characters long"),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
+});
+
+function parseServerEnv() {
+  const result = serverEnvSchema.safeParse(process.env);
+
+  if (!result.success) {
+    throw new Error(
+      `Invalid server environment variables:\n${result.error.issues
+        .map((issue) => `  ${issue.path.join(".")}: ${issue.message}`)
+        .join("\n")}`
+    );
+  }
+
+  return result.data;
+}
+
+export const serverEnv = parseServerEnv();

--- a/src/config/env.server.ts
+++ b/src/config/env.server.ts
@@ -18,7 +18,13 @@ const serverEnvSchema = z.object({
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
 });
 
-function parseServerEnv() {
+type ServerEnv = z.infer<typeof serverEnvSchema>;
+
+let cachedServerEnv: ServerEnv | undefined;
+
+function parseServerEnv(): ServerEnv {
+  if (cachedServerEnv) return cachedServerEnv;
+
   const result = serverEnvSchema.safeParse(process.env);
 
   if (!result.success) {
@@ -29,7 +35,19 @@ function parseServerEnv() {
     );
   }
 
-  return result.data;
+  cachedServerEnv = result.data;
+  return cachedServerEnv;
 }
 
-export const serverEnv = parseServerEnv();
+// Validated lazily, on first property access, rather than at import time.
+// `next build`'s page-data collection imports every route module (and so
+// transitively this one) without ever reading a property off `serverEnv` —
+// the production Dockerfile's builder stage only has the Sentry build args,
+// not these secrets, so eager validation here broke `next build`. Real
+// requests always read a property before the response is sent, so this
+// still validates before the value is ever used.
+export const serverEnv: ServerEnv = new Proxy({} as ServerEnv, {
+  get(_target, prop: keyof ServerEnv) {
+    return parseServerEnv()[prop];
+  },
+});

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,8 +1,9 @@
+import { clientEnv } from "@/config/env.client";
 import { sanitizeSentryEvent, sanitizeSentryLog } from "@/lib/sentryPrivacy";
 
 import * as Sentry from "@sentry/nextjs";
 
-const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const dsn = clientEnv.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,2 +1,3 @@
-export const BASE_URL =
-  process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000/api";
+import { clientEnv } from "@/config/env.client";
+
+export const BASE_URL = clientEnv.NEXT_PUBLIC_BASE_URL;

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -4,6 +4,7 @@ import jwt from "jsonwebtoken";
 
 import { Session } from "@/types/Session";
 import config from "@/config";
+import { serverEnv } from "@/config/env.server";
 
 const validatePassword = async (password: string, hashedPassword: string) => {
   return await bcrypt.compare(password, hashedPassword);
@@ -13,7 +14,7 @@ const signJwt = (
   data: Session | object | string,
   options?: jwt.SignOptions
 ) => {
-  const token = jwt.sign(data, process.env.JWT_SECRET as string, options);
+  const token = jwt.sign(data, serverEnv.JWT_SECRET, options);
   return token;
 };
 
@@ -27,7 +28,7 @@ const comparePassword = async (password: string, hashedPassword: string) => {
 
 const verifyJwt = (token: string, options?: jwt.VerifyOptions) => {
   try {
-    return jwt.verify(token, process.env.JWT_SECRET as string, options);
+    return jwt.verify(token, serverEnv.JWT_SECRET, options);
   } catch {
     return null;
   }
@@ -41,7 +42,7 @@ const setCookie = async (token: string) => {
     path: "/",
     sameSite: "strict",
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: serverEnv.NODE_ENV === "production",
   });
 };
 

--- a/src/services/getSession.ts
+++ b/src/services/getSession.ts
@@ -1,8 +1,9 @@
+import { clientEnv } from "@/config/env.client";
 import { UserWithProfile } from "@/types/UserWithProfile";
 
 const getSession = async () => {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/auth/session`,
+    `${clientEnv.NEXT_PUBLIC_BASE_URL}/auth/session`,
     { cache: "no-store" }
   );
   if (response.status !== 200) return null;

--- a/src/services/getSession.ts
+++ b/src/services/getSession.ts
@@ -1,5 +1,5 @@
-import { clientEnv } from "@/config/env.client";
 import { UserWithProfile } from "@/types/UserWithProfile";
+import { clientEnv } from "@/config/env.client";
 
 const getSession = async () => {
   const response = await fetch(

--- a/src/utils/supabase/admin.ts
+++ b/src/utils/supabase/admin.ts
@@ -1,10 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
 
+import { serverEnv } from "@/config/env.server";
+
 // Service-role client for privileged server operations (never exposed to client)
 export function createAdminClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  return createClient(url, serviceRoleKey, {
-    auth: { persistSession: false },
-  });
+  return createClient(
+    serverEnv.NEXT_PUBLIC_SUPABASE_URL,
+    serverEnv.SUPABASE_SERVICE_ROLE_KEY,
+    {
+      auth: { persistSession: false },
+    }
+  );
 }

--- a/src/utils/supabase/admin.ts
+++ b/src/utils/supabase/admin.ts
@@ -1,6 +1,6 @@
-import { createClient } from "@supabase/supabase-js";
-
 import { serverEnv } from "@/config/env.server";
+
+import { createClient } from "@supabase/supabase-js";
 
 // Service-role client for privileged server operations (never exposed to client)
 export function createAdminClient() {

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,7 +1,9 @@
 import { createBrowserClient } from "@supabase/ssr";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+import { clientEnv } from "@/config/env.client";
 
 export const createClient = () =>
-  createBrowserClient(supabaseUrl!, supabaseKey!);
+  createBrowserClient(
+    clientEnv.NEXT_PUBLIC_SUPABASE_URL,
+    clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  );

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,13 +1,15 @@
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 
+import { serverEnv } from "@/config/env.server";
+
 // SSR client for auth/session with public anon key
 export async function createClient() {
   const cookieStore = await cookies();
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    serverEnv.NEXT_PUBLIC_SUPABASE_URL,
+    serverEnv.SUPABASE_SERVICE_ROLE_KEY,
     {
       cookies: {
         getAll() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "allowUnreachableCode": true,
     "allowUnusedLabels": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- Add `src/config/env.server.ts` (server-only) and `env.client.ts`, single zod-validated env objects that fail fast with a clear error instead of the previous `process.env.JWT_SECRET as string` style casts (which let `JWT_SECRET` silently be `"undefined"`).
- Swap every raw `process.env` read for the validated objects (auth, Supabase clients, Sentry init, base URL).
- Flip `tsconfig.json` `strict: true` and fix the 3 files it newly broke.

closes #128 