### PR TITLE
chore: add code owner for PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dinisjcorreia @david-fs-valente


### PR DESCRIPTION
## Summary

- add default CODEOWNERS for all repository changes
- use the two active maintainers so either can review the other
- prepare automatic review requests for the `feat -> dev -> main` workflow

## GitHub settings blocker

GitHub currently rejects branch protection and rulesets for this private repository with: `Upgrade to GitHub Pro or make this repository public to enable this feature.`

After either change, configure `main` and `dev` to:

- require pull requests
- require at least one approval
- block direct pushes and force pushes
- require the `Typecheck & Lint` CI check

Refs #157. Dependency #124 is complete and CI is green.

## Verification

- `git diff --check`
- confirmed both CODEOWNERS have admin/write access