### PR TITLE
fix: enforce company-scoped uniqueness on SavedStudent

### DIFF
--- a/prisma/migrations/20260713000000_saved_student_company_scope/migration.sql
+++ b/prisma/migrations/20260713000000_saved_student_company_scope/migration.sql
@@ -1,0 +1,26 @@
+-- AlterTable: add companyId as nullable so it can be backfilled first
+ALTER TABLE "SavedStudent" ADD COLUMN "companyId" UUID;
+
+-- Backfill companyId from the saving employee's company
+UPDATE "SavedStudent" ss
+SET "companyId" = e."companyId"
+FROM "Employee" e
+WHERE e."id" = ss."employeeId";
+
+-- Collapse pre-existing duplicate company saves (same student saved by more
+-- than one employee of the same company), keeping the earliest save per
+-- (studentId, companyId) and dropping the rest.
+DELETE FROM "SavedStudent" ss
+USING "SavedStudent" keep
+WHERE ss."studentId" = keep."studentId"
+  AND ss."companyId" = keep."companyId"
+  AND (ss."createdAt", ss."employeeId") > (keep."createdAt", keep."employeeId");
+
+-- AlterTable: enforce NOT NULL now that every row is backfilled
+ALTER TABLE "SavedStudent" ALTER COLUMN "companyId" SET NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SavedStudent_studentId_companyId_key" ON "SavedStudent"("studentId", "companyId");
+
+-- AddForeignKey
+ALTER TABLE "SavedStudent" ADD CONSTRAINT "SavedStudent_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,7 +50,8 @@ model Company {
 
   code String? @unique
 
-  employees Employee[]
+  employees     Employee[]
+  savedStudents SavedStudent[]
 
   @@index([name])
 }
@@ -107,12 +108,15 @@ model Interest {
 model SavedStudent {
   studentId  String   @db.Uuid
   employeeId String   @db.Uuid
+  companyId  String   @db.Uuid
   student    Student  @relation(fields: [studentId], references: [id], onDelete: Cascade)
   savedBy    Employee @relation(fields: [employeeId], references: [id], onDelete: Cascade)
+  company    Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
   createdAt  DateTime @default(now())
   comment    String?
 
   @@id([studentId, employeeId])
+  @@unique([studentId, companyId])
 }
 
 enum Role {

--- a/src/application/repositories/savedStudentRepository.ts
+++ b/src/application/repositories/savedStudentRepository.ts
@@ -12,17 +12,23 @@ import prisma, { DbClient } from "./database";
 
 export const isStudentSaved = async (companyId: string, code: string) =>
   !!(await prisma.savedStudent.findFirst({
-    where: { AND: [{ savedBy: { companyId } }, { student: { code } }] },
+    where: { companyId, student: { code } },
   }));
 
 export const createSavedStudent = (
   studentId: string,
   employeeId: string,
+  companyId: string,
   db: DbClient = prisma,
   comment?: string | null
 ) =>
   db.savedStudent.create({
-    data: { studentId, employeeId, ...savedStudentCommentData(comment) },
+    data: {
+      studentId,
+      employeeId,
+      companyId,
+      ...savedStudentCommentData(comment),
+    },
   });
 
 export const updateSavedStudentComment = (
@@ -37,7 +43,7 @@ export const updateSavedStudentComment = (
 
 export const findSavedStudent = (studentId: string, companyId: string) =>
   prisma.savedStudent.findFirst({
-    where: { studentId, savedBy: { companyId } },
+    where: { studentId, companyId },
   });
 
 export const countStudentSaves = (code: string) =>
@@ -49,18 +55,18 @@ export const countStudentSavesSince = (studentId: string, since: Date) =>
   });
 
 export const countCompanySaves = (companyId: string) =>
-  prisma.savedStudent.count({ where: { savedBy: { companyId } } });
+  prisma.savedStudent.count({ where: { companyId } });
 
 export const findCompanyHistory = (companyId: string) =>
   prisma.savedStudent.findMany({
-    where: { savedBy: { companyId } },
+    where: { companyId },
     include: { savedBy: { include: { company: true } }, student: true },
     orderBy: { createdAt: "desc" },
   });
 
 export const findCompanyHistoryWithInterests = (companyId: string) =>
   prisma.savedStudent.findMany({
-    where: { savedBy: { companyId } },
+    where: { companyId },
     include: {
       student: {
         select: {
@@ -77,7 +83,7 @@ export const findCompanyHistoryWithInterests = (companyId: string) =>
 
 export const findCompanySavedStudentsWithCv = (companyId: string) =>
   prisma.savedStudent.findMany({
-    where: { savedBy: { companyId } },
+    where: { companyId },
     include: {
       student: { select: { id: true, name: true, code: true, cv: true } },
     },
@@ -85,7 +91,7 @@ export const findCompanySavedStudentsWithCv = (companyId: string) =>
 
 export const findCompanySavesForExport = (companyId: string) =>
   prisma.savedStudent.findMany({
-    where: { savedBy: { companyId } },
+    where: { companyId },
     include: { student: { include: { user: true } } },
     orderBy: { createdAt: "asc" },
   });

--- a/src/application/services/savedStudentService.ts
+++ b/src/application/services/savedStudentService.ts
@@ -53,6 +53,7 @@ export async function saveStudent(input: {
       const saved = await createSavedStudent(
         student.id,
         input.employeeId,
+        input.companyId,
         tx,
         input.comment
       );

--- a/src/application/services/savedStudentService.ts
+++ b/src/application/services/savedStudentService.ts
@@ -3,8 +3,8 @@ import "server-only";
 import { Email } from "@/types/Email";
 import { HttpError } from "@/types/HttpError";
 import type { Stats } from "@/types/Stats";
-import { ISEP_EMAIL_DOMAIN } from "@/utils/isepEmail";
 import { getBoothActionName } from "@/edition/actions";
+import { ISEP_EMAIL_DOMAIN } from "@/utils/isepEmail";
 
 import { assertStudentCanBeSaved } from "../domain/saveRules";
 import {

--- a/src/lib/savedStudentComments.test.ts
+++ b/src/lib/savedStudentComments.test.ts
@@ -20,7 +20,7 @@ test("add, edit, and remove preserve intended comment values", () => {
 test("comment updates are scoped to the logged-in company", () => {
   assert.deepEqual(savedStudentCompanyWhere("student-id", "company-id"), {
     studentId: "student-id",
-    savedBy: { companyId: "company-id" },
+    companyId: "company-id",
   });
 });
 

--- a/src/lib/savedStudentComments.ts
+++ b/src/lib/savedStudentComments.ts
@@ -11,7 +11,7 @@ export function savedStudentCommentData(comment?: string | null) {
 }
 
 export function savedStudentCompanyWhere(studentId: string, companyId: string) {
-  return { studentId, savedBy: { companyId } };
+  return { studentId, companyId };
 }
 
 function csvCell(value: string) {


### PR DESCRIPTION
## Summary
- `SavedStudent`'s primary key is `(studentId, employeeId)` (employee-scoped), but the dedup rule the app enforces (`isStudentSaved`) is company-scoped, so two employees at the same company could race and both save the same student — no DB backstop.
- Adds a `companyId` column to `SavedStudent` with a `@@unique([studentId, companyId])` constraint, so the database now enforces the same grain the app assumes.
- Migration backfills `companyId` from the saving employee, and collapses any pre-existing duplicate company saves (keeping the earliest one) before adding the constraint.
- Repository queries (`countCompanySaves`, `findCompanyHistory`, etc.) now filter on the direct `companyId` column instead of joining through `savedBy.companyId`.

Closes #151