### PR TITLE
refactor: add error/loading handling to client mutations

### DIFF
--- a/src/components/Action/CloseActionButton/index.tsx
+++ b/src/components/Action/CloseActionButton/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMutation } from "@/hooks/useMutation";
 import PrimaryButton from "@/components/PrimaryButton";
 
 interface CloseActionButtonProps {
@@ -13,17 +14,27 @@ const CloseActionButton: React.FC<CloseActionButtonProps> = ({
   id,
   action,
 }) => {
-  const handleToggleIsActionLive = async () => {
-    await fetch(`/api/actions/${id}`, {
-      method: "PATCH",
-    });
+  const { mutate, isPending } = useMutation(
+    "Não foi possível atualizar o estado da ação."
+  );
 
-    window.location.reload();
-  };
+  const handleToggleIsActionLive = () =>
+    mutate(async () => {
+      const res = await fetch(`/api/actions/${id}`, {
+        method: "PATCH",
+      });
+
+      if (!res.ok) {
+        throw new Error("Não foi possível atualizar o estado da ação.");
+      }
+
+      window.location.reload();
+    });
 
   return (
     <PrimaryButton
       onClick={handleToggleIsActionLive}
+      loading={isPending}
       className={`absolute top-24 right-4 h-12 w-32 text-lg font-bold md:right-8 md:w-64 md:text-xl ${
         action.isLive ? "bg-red-500" : "bg-green-500"
       }`}

--- a/src/components/AdminSavedSection/index.tsx
+++ b/src/components/AdminSavedSection/index.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import Swal from "sweetalert";
 
+import { useMutation } from "@/hooks/useMutation";
 import { BASE_URL } from "@/services/api";
 import type { CompanyDto } from "@/application/dto/companyDto";
 
@@ -13,28 +14,31 @@ interface AdminSavedSectionProps {
 const AdminSavedSection: React.FC<AdminSavedSectionProps> = ({ companies }) => {
   const [studentEmailNumber, setStudentEmailNumber] = useState("");
   const [selectedCompany, setSelectedCompany] = useState("");
+  const { mutate, isPending } = useMutation();
 
-  const handleSubmit = async (event: React.FormEvent) => {
+  const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
 
-    const response = await fetch(`${BASE_URL}/admin/save-student`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        studentEmailNumber,
-        companyId: selectedCompany,
-      }),
-    });
+    mutate(async () => {
+      const response = await fetch(`${BASE_URL}/admin/save-student`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          studentEmailNumber,
+          companyId: selectedCompany,
+        }),
+      });
 
-    const result = await response.json();
+      const result = await response.json();
 
-    if (response.ok) {
+      if (!response.ok) {
+        throw new Error(result.error || "Failed to save student");
+      }
+
       Swal("Success", "Student saved successfully!", "success");
-    } else {
-      Swal("Error", result.error, "error");
-    }
+    });
   };
 
   return (
@@ -78,9 +82,10 @@ const AdminSavedSection: React.FC<AdminSavedSectionProps> = ({ companies }) => {
         </label>
         <button
           type="submit"
-          className="rounded-md bg-blue-500 p-2 text-white hover:bg-blue-600"
+          disabled={isPending}
+          className="rounded-md bg-blue-500 p-2 text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
         >
-          Save Student
+          {isPending ? "A guardar..." : "Save Student"}
         </button>
       </form>
     </div>

--- a/src/components/Companies/CompanyProfile/CompanyProfileSectionContainer/index.tsx
+++ b/src/components/Companies/CompanyProfile/CompanyProfileSectionContainer/index.tsx
@@ -1,14 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import { BiScan } from "react-icons/bi";
 import { FiChevronRight, FiFileText, FiLogOut } from "react-icons/fi";
-import swal from "sweetalert";
 
 import type { Stats } from "@/types/Stats";
-import useSession from "@/hooks/useSession";
-import { BASE_URL } from "@/services/api";
+import { useLogout } from "@/hooks/useLogout";
 import CompanyImage from "@/components/Companies/CompanyProfile/CompanyImage";
 import CompanySavedProfilesSection from "@/components/Companies/CompanyProfile/CompanySavedProfilesSection";
 import CompanyStatsSection from "@/components/Companies/CompanyProfile/CompanyStatsSection";
@@ -52,8 +49,7 @@ const CompanyProfileSectionContainer: React.FC<
   history,
   interests,
 }) => {
-  const router = useRouter();
-  const session = useSession();
+  const handleLogout = useLogout();
 
   const [activeTab, setActiveTab] = useState<TabValue>("Sumário");
   const [selectedMenu, setSelectedMenu] = useState<MenuKey>(menuMap[activeTab]);
@@ -81,25 +77,6 @@ const CompanyProfileSectionContainer: React.FC<
     if (item.tabValue) {
       setActiveTab(item.tabValue);
     }
-  };
-
-  const handleLogout = async () => {
-    swal("Queres mesmo mesmo sair?", {
-      buttons: ["Cancelar", "Sair"],
-      title: "Terminar sessão",
-      icon: "warning",
-      dangerMode: true,
-      timer: 5000,
-    }).then(async (value) => {
-      if (value) {
-        const res = await fetch(BASE_URL + "/auth/logout", { method: "POST" });
-        if (res.status === 200) {
-          session.clear();
-          swal("Logout", "Sessão terminada com sucesso", "success");
-          router.push("/");
-        }
-      }
-    });
   };
 
   const renderButton = (item: SidebarItem) => {

--- a/src/components/Companies/CompanyProfile/CompanySavedProfilesSection/index.tsx
+++ b/src/components/Companies/CompanyProfile/CompanySavedProfilesSection/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "react-toastify";
 import swal from "sweetalert";
 
+import { useMutation } from "@/hooks/useMutation";
 import { BASE_URL } from "@/services/api";
 import CompanySavesSection from "@/components/Companies/CompanyProfile/CompanyHistorySection";
 import QRCodeScanner from "@/components/QRCode/QRCodeScanner";
@@ -15,6 +16,8 @@ const CompanySavedProfilesSection = () => {
   const [downloading, setDownloading] = useState<boolean>(false);
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
+  const { mutate: mutateManualEntry, isPending: isSubmittingManualEntry } =
+    useMutation("Ocorreu um erro.");
 
   function handleStudentProfileOpen(data: string) {
     if (data.startsWith(window.location.origin)) {
@@ -84,19 +87,20 @@ const CompanySavedProfilesSection = () => {
     }
   };
 
-  const handleManualEntry = async () => {
-    if (!inputRef.current?.value) {
-      toast.error("Sem código inserido.");
-      return;
-    }
+  const handleManualEntry = () =>
+    mutateManualEntry(async () => {
+      if (!inputRef.current?.value) {
+        toast.error("Sem código inserido.");
+        return;
+      }
 
-    const code = inputRef.current?.value;
-
-    if (code) {
+      const code = inputRef.current?.value;
       const token = await jwtStudent(code);
 
-      if (!token)
-        return swal("Erro", "O código introduzido é inválido.", "error");
+      if (!token) {
+        swal("Erro", "O código introduzido é inválido.", "error");
+        return;
+      }
 
       const res = await fetch(BASE_URL + "/saved", {
         method: "POST",
@@ -117,10 +121,7 @@ const CompanySavedProfilesSection = () => {
         return;
       }
       router.push(`/student/${token}/preview`);
-    } else {
-      toast.error("Ocorreu um erro.");
-    }
-  };
+    });
 
   const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") handleManualEntry();
@@ -214,17 +215,19 @@ const CompanySavedProfilesSection = () => {
             ref={inputRef}
             onKeyUp={handleKeyUp}
             maxLength={4}
+            disabled={isSubmittingManualEntry}
           />
           <button
             onClick={handleManualEntry}
-            className="absolute top-2 right-2 bottom-2 flex w-[104px] items-center justify-center bg-[#82360D] text-base text-white hover:opacity-90"
+            disabled={isSubmittingManualEntry}
+            className="absolute top-2 right-2 bottom-2 flex w-[104px] items-center justify-center bg-[#82360D] text-base text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
             style={{
               fontFamily: "Inter",
               fontWeight: 400,
               lineHeight: "100%",
             }}
           >
-            Validar
+            {isSubmittingManualEntry ? "..." : "Validar"}
           </button>
         </div>
         <p

--- a/src/components/Companies/CompanyProfile/CompanyStatsSection/index.tsx
+++ b/src/components/Companies/CompanyProfile/CompanyStatsSection/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import swal from "sweetalert";
 
 import type { Stats } from "@/types/Stats";
+import { useMutation } from "@/hooks/useMutation";
 import { BASE_URL } from "@/services/api";
 import HistorySection from "@/components/HistorySection";
 import PrimaryButton from "@/components/PrimaryButton";
@@ -27,27 +28,27 @@ const CompanyStatsSection: React.FC<StatsProps> = ({
   const { totalScans, totalSaves } = stats;
   const studentsLeft = students - totalScans;
   const [companyInterests, setInterests] = useState<string[]>(interests);
-  const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
+  const { mutate, isPending } = useMutation(
+    "Ocorreu um erro ao atualizar o teu perfil..."
+  );
 
-  async function handleSave() {
-    const res = await fetch(`${BASE_URL}/user`, {
-      method: "PATCH",
-      body: JSON.stringify({
-        interests: companyInterests,
-      }),
-    });
+  const handleSave = () =>
+    mutate(async () => {
+      const res = await fetch(`${BASE_URL}/user`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          interests: companyInterests,
+        }),
+      });
 
-    if (res.status === 200) {
-      setIsLoading(false);
+      if (!res.ok) {
+        throw new Error("Ocorreu um erro ao atualizar o teu perfil...");
+      }
+
       swal("Perfil atualizado com sucesso!");
-    } else {
-      setIsLoading(false);
-      swal("Ocorreu um erro ao atualizar o teu perfil...");
-    }
-
-    router.refresh();
-  }
+      router.refresh();
+    });
 
   return (
     <section className="flex w-full flex-col items-center justify-center rounded-t-3xl p-4 md:rounded-md md:p-8">
@@ -83,7 +84,7 @@ const CompanyStatsSection: React.FC<StatsProps> = ({
       />
       <PrimaryButton
         onClick={handleSave}
-        loading={isLoading}
+        loading={isPending}
         className="mt-4 px-12 py-2 text-lg"
       >
         Guardar

--- a/src/components/Companies/CompanyProfile/CompanyViewProfileSectionContainer/index.tsx
+++ b/src/components/Companies/CompanyProfile/CompanyViewProfileSectionContainer/index.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 import swal from "sweetalert";
 
+import { useMutation } from "@/hooks/useMutation";
 import { BASE_URL } from "@/services/api";
 import BioSection from "@/components/Profile/BioSection";
 import ContactSection from "@/components/Profile/ContactSection";
@@ -24,36 +25,33 @@ const CompanyViewProfileSectionContainer: React.FC<
   CompanyViewProfileSectionContainerProps
 > = ({ student, interests, token, isSavedStudent }) => {
   const [comment, setComment] = useState("");
+  const { mutate, isPending } = useMutation("Erro ao salvar perfil!");
 
-  const handleSaveProfile = async () => {
-    const res = await fetch(BASE_URL + "/saved", {
-      method: "PATCH",
-      body: JSON.stringify({ token, comment }),
-      headers: { "Content-Type": "application/json" },
-    });
+  const handleSaveProfile = () =>
+    mutate(async () => {
+      const res = await fetch(BASE_URL + "/saved", {
+        method: "PATCH",
+        body: JSON.stringify({ token, comment }),
+        headers: { "Content-Type": "application/json" },
+      });
 
-    if (res.status === 200) {
-      swal({
-        title: "Success",
-        text: "Perfil salvo com sucesso!",
-        icon: "success",
-      }).then(() => {
+      if (res.status === 200) {
+        await swal({
+          title: "Success",
+          text: "Perfil salvo com sucesso!",
+          icon: "success",
+        });
         window.location.reload();
-      });
-    } else if (res.status === 400) {
-      swal({
-        title: "Warning",
-        text: "Perfil já salvo!",
-        icon: "warning",
-      });
-    } else {
-      swal({
-        title: "Error",
-        text: "Erro ao salvar perfil!",
-        icon: "error",
-      });
-    }
-  };
+      } else if (res.status === 400) {
+        swal({
+          title: "Warning",
+          text: "Perfil já salvo!",
+          icon: "warning",
+        });
+      } else {
+        throw new Error("Erro ao salvar perfil!");
+      }
+    });
 
   return (
     <div
@@ -105,9 +103,10 @@ const CompanyViewProfileSectionContainer: React.FC<
                 />
                 <button
                   onClick={handleSaveProfile}
-                  className="rounded-lg bg-primary px-3 font-bold hover:scale-105 hover:bg-primary/100 hover:shadow-xl"
+                  disabled={isPending}
+                  className="rounded-lg bg-primary px-3 font-bold hover:scale-105 hover:bg-primary/100 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  + Salvar Perfil
+                  {isPending ? "A guardar..." : "+ Salvar Perfil"}
                 </button>
               </div>
             )}

--- a/src/components/LogoutButton/index.tsx
+++ b/src/components/LogoutButton/index.tsx
@@ -1,34 +1,11 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { BiLogOut } from "react-icons/bi";
-import swal from "sweetalert";
 
-import useSession from "@/hooks/useSession";
-import { BASE_URL } from "@/services/api";
+import { useLogout } from "@/hooks/useLogout";
 
 const LogoutButton: React.FC = () => {
-  const session = useSession();
-  const router = useRouter();
-
-  const handleClick = async () => {
-    swal("Queres mesmo mesmo sair?", {
-      buttons: ["Cancelar", "Sair"],
-      title: "Terminar sessão",
-      icon: "warning",
-      dangerMode: true,
-      timer: 5000,
-    }).then(async (value) => {
-      if (value) {
-        const res = await fetch(BASE_URL + "/auth/logout", { method: "POST" });
-        if (res.status === 200) {
-          session.clear();
-          swal("Logout", "Sessão terminada com sucesso", "success");
-          router.push("/");
-        }
-      }
-    });
-  };
+  const handleClick = useLogout();
 
   return (
     <button

--- a/src/components/Profile/PreviewProfileSectionContainer/index.tsx
+++ b/src/components/Profile/PreviewProfileSectionContainer/index.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import swal from "sweetalert";
 
+import { useMutation } from "@/hooks/useMutation";
 import { BASE_URL } from "@/services/api";
 import UserImage from "@/components/Profile/UserImage";
 import type { StudentDto } from "@/application/dto/studentDto";
@@ -27,36 +28,34 @@ const PreviewProfileSectionContainer: React.FC<
     [interests]
   );
   const router = useRouter();
-  const handleSaveProfile = async () => {
-    if (!token) return;
+  const { mutate, isPending } = useMutation("Erro ao salvar perfil!");
 
-    const res = await fetch(BASE_URL + "/saved", {
-      method: "PATCH",
-      body: JSON.stringify({ token }),
-    });
+  const handleSaveProfile = () =>
+    mutate(async () => {
+      if (!token) return;
 
-    if (res.status === 200) {
-      swal({
-        title: "Success",
-        text: "Perfil salvo com sucesso!",
-        icon: "success",
-      }).then(() => {
+      const res = await fetch(BASE_URL + "/saved", {
+        method: "PATCH",
+        body: JSON.stringify({ token }),
+      });
+
+      if (res.status === 200) {
+        await swal({
+          title: "Success",
+          text: "Perfil salvo com sucesso!",
+          icon: "success",
+        });
         window.location.reload();
-      });
-    } else if (res.status === 400) {
-      swal({
-        title: "Warning",
-        text: "Perfil já salvo!",
-        icon: "warning",
-      });
-    } else {
-      swal({
-        title: "Error",
-        text: "Erro ao salvar perfil!",
-        icon: "error",
-      });
-    }
-  };
+      } else if (res.status === 400) {
+        swal({
+          title: "Warning",
+          text: "Perfil já salvo!",
+          icon: "warning",
+        });
+      } else {
+        throw new Error("Erro ao salvar perfil!");
+      }
+    });
 
   const handleOpenCv = async () => {
     const res = await fetch(BASE_URL + `/students/${student.code}/cv`);
@@ -141,9 +140,10 @@ const PreviewProfileSectionContainer: React.FC<
           {isCompanyView && !isSavedStudent && (
             <button
               onClick={handleSaveProfile}
-              className="rounded-full border border-primary/60 bg-primary px-4 py-2 font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl"
+              disabled={isPending}
+              className="rounded-full border border-primary/60 bg-primary px-4 py-2 font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-60"
             >
-              + Salvar perfil
+              {isPending ? "A guardar..." : "+ Salvar perfil"}
             </button>
           )}
         </div>

--- a/src/components/Profile/ProfileSection/index.tsx
+++ b/src/components/Profile/ProfileSection/index.tsx
@@ -8,6 +8,7 @@ import { toast } from "react-toastify";
 import swal from "sweetalert";
 
 import { ProfileData } from "@/types/ProfileData";
+import { useMutation } from "@/hooks/useMutation";
 import { BASE_URL } from "@/services/api";
 import Modal from "@/components/Modal";
 import PrimaryButton from "@/components/PrimaryButton";
@@ -46,7 +47,9 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
   const linkedinRef = useRef<HTMLInputElement>(null);
   const cvRef = useRef<HTMLInputElement>(null);
 
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const { mutate: mutateSave, isPending: isLoading } = useMutation(
+    "Erro ao atualizar perfil."
+  );
   const [userImage, setUserImage] = useState<string | null>(student.avatar);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
@@ -84,7 +87,7 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
     setProfile({ ...profile, avatar: uploaded.url as unknown as string });
   };
 
-  const handleSave = async () => {
+  const handleSave = () => {
     if (profile.bio && profile.bio?.length > LIMIT) {
       swal(`A tua bio não pode ter mais de ${LIMIT} caracteres!`);
       return;
@@ -112,36 +115,38 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
       return;
     }
 
-    setIsLoading(true);
-
     setProfile({
       ...profile,
       linkedin: linkedinRef.current?.value || null,
       github: githubRef.current?.value || null,
     });
 
-    if (cvRef.current?.files?.length) {
-      const cvFile = cvRef.current.files[0]!;
-      const uploaded = await uploadCvToSupabase(cvFile);
-      if (uploaded) {
-        await fetch(`${BASE_URL}/students/${student.code}/cv`, {
-          method: "POST",
-          body: JSON.stringify({ id: uploaded.id }),
-        });
+    mutateSave(async () => {
+      if (cvRef.current?.files?.length) {
+        const cvFile = cvRef.current.files[0]!;
+        const uploaded = await uploadCvToSupabase(cvFile);
+        if (uploaded) {
+          await fetch(`${BASE_URL}/students/${student.code}/cv`, {
+            method: "POST",
+            body: JSON.stringify({ id: uploaded.id }),
+          });
+        }
       }
-    }
 
-    const res = await fetch(`${BASE_URL}/students/${student.code}`, {
-      method: "PATCH",
-      body: JSON.stringify({
-        bio: profile.bio ? profile.bio : undefined,
-        github: githubRef.current?.value,
-        linkedin: linkedinRef.current?.value,
-        interests: profile.interests,
-      }),
-    });
+      const res = await fetch(`${BASE_URL}/students/${student.code}`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          bio: profile.bio ? profile.bio : undefined,
+          github: githubRef.current?.value,
+          linkedin: linkedinRef.current?.value,
+          interests: profile.interests,
+        }),
+      });
 
-    if (res.status === 200) {
+      if (!res.ok) {
+        throw new Error("Erro ao atualizar perfil.");
+      }
+
       if (profile.avatar) {
         const avatarRes = await fetch(
           `${BASE_URL}/students/${student.code}/avatar`,
@@ -156,14 +161,10 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
         }
       }
 
-      setIsLoading(false);
       swal("Perfil atualizado com sucesso!");
       setActiveTab("Perfil");
       router.refresh();
-    } else {
-      setIsLoading(false);
-      swal("Erro ao atualizar perfil.");
-    }
+    });
   };
 
   return (

--- a/src/components/Profile/ProfileSectionContainer/index.tsx
+++ b/src/components/Profile/ProfileSectionContainer/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import {
   FiChevronRight,
   FiFileText,
@@ -10,12 +9,11 @@ import {
   FiMapPin,
   FiUser,
 } from "react-icons/fi";
-import swal from "sweetalert";
 
 import { ProfileData } from "@/types/ProfileData";
 import type { Stats } from "@/types/Stats";
+import { useLogout } from "@/hooks/useLogout";
 import useSession from "@/hooks/useSession";
-import { BASE_URL } from "@/services/api";
 import PassMenuContent from "@/components/PassSection/PassMenuContent";
 import UserImage from "@/components/Profile/UserImage";
 import type { StudentActionDto } from "@/application/dto/actionDto";
@@ -56,8 +54,8 @@ const ProfileSectionContainer: React.FC<ProfileSectionContainerProps> = ({
   historyData,
   actions,
 }) => {
-  const router = useRouter();
   const session = useSession();
+  const handleLogout = useLogout();
 
   const [activeTab, setActiveTab] = useState<TabValue>("Sumário");
   const [selectedMenu, setSelectedMenu] = useState<MenuKey>(menuMap[activeTab]);
@@ -106,25 +104,6 @@ const ProfileSectionContainer: React.FC<ProfileSectionContainerProps> = ({
     if (item.tabValue) {
       setActiveTab(item.tabValue);
     }
-  };
-
-  const handleLogout = async () => {
-    swal("Queres mesmo mesmo sair?", {
-      buttons: ["Cancelar", "Sair"],
-      title: "Terminar sessão",
-      icon: "warning",
-      dangerMode: true,
-      timer: 5000,
-    }).then(async (value) => {
-      if (value) {
-        const res = await fetch(BASE_URL + "/auth/logout", { method: "POST" });
-        if (res.status === 200) {
-          session.clear();
-          swal("Logout", "Sessão terminada com sucesso", "success");
-          router.push("/");
-        }
-      }
-    });
   };
 
   const renderButton = (item: SidebarItem) => {

--- a/src/components/Profile/SettingsSection/index.tsx
+++ b/src/components/Profile/SettingsSection/index.tsx
@@ -8,6 +8,7 @@ import { toast } from "react-toastify";
 import swal from "sweetalert";
 
 import { ProfileData } from "@/types/ProfileData";
+import { useMutation } from "@/hooks/useMutation";
 import { BASE_URL } from "@/services/api";
 import Modal from "@/components/Modal";
 import PrimaryButton from "@/components/PrimaryButton";
@@ -47,7 +48,9 @@ const SettingsSection: React.FC<SettingsSectionProps> = ({
   const linkedinRef = useRef<HTMLInputElement>(null);
   const cvRef = useRef<HTMLInputElement>(null);
 
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const { mutate: mutateSave, isPending: isLoading } = useMutation(
+    "Erro ao atualizar perfil."
+  );
   const [userImage, setUserImage] = useState<string | null>(student.avatar);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
@@ -64,7 +67,7 @@ const SettingsSection: React.FC<SettingsSectionProps> = ({
     setProfile({ ...profile, interests });
   }
 
-  const handleSave = async () => {
+  const handleSave = () => {
     if (profile.bio && profile.bio?.length > LIMIT) {
       swal(`A tua bio não pode ter mais de ${LIMIT} caracteres!`);
       return;
@@ -92,53 +95,48 @@ const SettingsSection: React.FC<SettingsSectionProps> = ({
       return;
     }
 
-    setIsLoading(true);
-
     setProfile({
       ...profile,
       linkedin: linkedinRef.current?.value || null,
       github: githubRef.current?.value || null,
     });
 
-    if (cvRef.current?.files?.length) {
-      const cvFile = cvRef.current.files[0]!;
-      const uploaded = await uploadCvToSupabase(cvFile);
-      if (uploaded) {
-        await fetch(`${BASE_URL}/students/${student.code}/cv`, {
-          method: "POST",
-          body: JSON.stringify({ id: uploaded.id }),
-        });
+    mutateSave(async () => {
+      if (cvRef.current?.files?.length) {
+        const cvFile = cvRef.current.files[0]!;
+        const uploaded = await uploadCvToSupabase(cvFile);
+        if (uploaded) {
+          await fetch(`${BASE_URL}/students/${student.code}/cv`, {
+            method: "POST",
+            body: JSON.stringify({ id: uploaded.id }),
+          });
+        }
       }
-    }
 
-    const res = await fetch(`${BASE_URL}/students/${student.code}`, {
-      method: "PATCH",
-      body: JSON.stringify({
-        bio: profile.bio ? profile.bio : undefined,
-        github: githubRef.current?.value,
-        linkedin: linkedinRef.current?.value,
-        interests: profile.interests,
-      }),
-    });
+      const res = await fetch(`${BASE_URL}/students/${student.code}`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          bio: profile.bio ? profile.bio : undefined,
+          github: githubRef.current?.value,
+          linkedin: linkedinRef.current?.value,
+          interests: profile.interests,
+        }),
+      });
 
-    if (res.status === 200) {
+      if (!res.ok) {
+        throw new Error("Erro ao atualizar perfil.");
+      }
+
       if (profile.avatar)
         await fetch(`${BASE_URL}/students/${student.code}/avatar`, {
           method: "POST",
           body: JSON.stringify({ url: profile.avatar }),
         });
 
-      setIsLoading(false);
       swal("Perfil atualizado com sucesso!");
       setActiveTab("Perfil");
       router.refresh();
-    } else {
-      setIsLoading(false);
-      // swal("Ocorreu um erro ao atualizar o teu perfil...");
-      swal("Perfil atualizado com sucesso!");
-      setActiveTab("Perfil");
-      router.refresh();
-    }
+    });
   };
 
   const handleConfirmAvatar = async () => {

--- a/src/components/QRCode/QRCodeTab/CompanyTab/index.tsx
+++ b/src/components/QRCode/QRCodeTab/CompanyTab/index.tsx
@@ -46,7 +46,7 @@ const CompanyTab: React.FC<CompanyTabProps> = ({ setHidden }) => {
 
       const res = await fetch(BASE_URL + "/saved", {
         method: "POST",
-        body: JSON.stringify({ code }),
+        body: JSON.stringify({ token }),
       });
 
       if (!res.ok) {

--- a/src/components/QRCode/QRCodeTab/CompanyTab/index.tsx
+++ b/src/components/QRCode/QRCodeTab/CompanyTab/index.tsx
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import swal from "sweetalert";
 
 import useIsMobile from "@/hooks/useIsMobile";
+import { useMutation } from "@/hooks/useMutation";
 import { BASE_URL } from "@/services/api";
 import ScanTab from "@/components/QRCode/QRCodeTab/ScanTab";
 import { jwtStudent } from "@/application/services/studentTokenService";
@@ -22,34 +23,49 @@ const CompanyTab: React.FC<CompanyTabProps> = ({ setHidden }) => {
   const router = useRouter();
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const { mutate, isPending } = useMutation("Ocorreu um erro.");
 
   const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") handleClick();
   };
 
-  const handleClick = async () => {
-    if (!inputRef.current?.value) toast.error("Sem código inserido.");
+  const handleClick = () =>
+    mutate(async () => {
+      if (!inputRef.current?.value) {
+        toast.error("Sem código inserido.");
+        return;
+      }
 
-    const code = inputRef.current?.value;
-
-    if (code) {
+      const code = inputRef.current?.value;
       const token = await jwtStudent(code);
 
-      if (!token)
-        return swal("Erro", "O código introduzido é inválido.", "error");
+      if (!token) {
+        swal("Erro", "O código introduzido é inválido.", "error");
+        return;
+      }
 
-      await fetch(BASE_URL + "/saved", {
+      const res = await fetch(BASE_URL + "/saved", {
         method: "POST",
         body: JSON.stringify({ code }),
       });
 
-      router.push(`/student/${token}/preview`);
+      if (!res.ok) {
+        const { error } = await res.json();
+        if (res.status === 409) {
+          swal(
+            "Aviso",
+            "Este estudante já foi guardado anteriormente.",
+            "warning"
+          );
+        } else {
+          throw new Error(error || "Ocorreu um erro.");
+        }
+        return;
+      }
 
+      router.push(`/student/${token}/preview`);
       setHidden(true);
-    } else {
-      toast.error("Ocorreu um erro.");
-    }
-  };
+    });
 
   return (
     <div className="mt-14 flex flex-col items-center justify-center">
@@ -66,6 +82,7 @@ const CompanyTab: React.FC<CompanyTabProps> = ({ setHidden }) => {
                   ref={inputRef}
                   onKeyUp={handleKeyUp}
                   maxLength={4}
+                  disabled={isPending}
                 />
               </div>
             </div>
@@ -73,9 +90,10 @@ const CompanyTab: React.FC<CompanyTabProps> = ({ setHidden }) => {
               whileTap={{ scale: 0.9 }}
               initial={{ scale: 1 }}
               onClick={handleClick}
-              className="mt-4 rounded-xl bg-primary px-4 py-2 text-lg font-bold text-white hover:opacity-50"
+              disabled={isPending}
+              className="mt-4 rounded-xl bg-primary px-4 py-2 text-lg font-bold text-white hover:opacity-50 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              Ir para o perfil
+              {isPending ? "A processar..." : "Ir para o perfil"}
             </motion.button>
           </div>
         </>

--- a/src/components/QRCode/QRCodeTab/ScanTab/index.tsx
+++ b/src/components/QRCode/QRCodeTab/ScanTab/index.tsx
@@ -59,10 +59,25 @@ const ScanTab: React.FC<ScanTabProps> = ({ setHidden }) => {
         return;
       }
 
-      await fetch(BASE_URL + "/saved", {
+      const res = await fetch(BASE_URL + "/saved", {
         method: "POST",
         body: JSON.stringify({ token: data }),
       });
+
+      if (!res.ok) {
+        const { error } = await res.json();
+        if (res.status === 409) {
+          swal(
+            "Aviso",
+            "Este estudante já foi guardado anteriormente.",
+            "warning"
+          );
+        } else {
+          toast.error(error || "Erro ao guardar perfil");
+        }
+        setProcessing(false);
+        return;
+      }
 
       setHidden(true);
       router.push(`/student/${data}/preview`);

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import swal from "sweetalert";
+
+import { BASE_URL } from "@/services/api";
+
+import useSession from "./useSession";
+
+export function useLogout() {
+  const session = useSession();
+  const router = useRouter();
+
+  return async () => {
+    const confirmed = await swal("Queres mesmo mesmo sair?", {
+      buttons: ["Cancelar", "Sair"],
+      title: "Terminar sessão",
+      icon: "warning",
+      dangerMode: true,
+      timer: 5000,
+    });
+
+    if (!confirmed) return;
+
+    try {
+      const res = await fetch(BASE_URL + "/auth/logout", { method: "POST" });
+      if (!res.ok) throw new Error("Não foi possível terminar a sessão.");
+
+      session.clear();
+      await swal("Logout", "Sessão terminada com sucesso", "success");
+      router.push("/");
+    } catch (error) {
+      swal(
+        "Erro",
+        error instanceof Error
+          ? error.message
+          : "Não foi possível terminar a sessão.",
+        "error"
+      );
+    }
+  };
+}

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "react-toastify";
+
+const DEFAULT_ERROR_MESSAGE = "Ocorreu um erro. Tenta novamente.";
+
+export function useMutation(fallbackErrorMessage = DEFAULT_ERROR_MESSAGE) {
+  const [isPending, setIsPending] = useState(false);
+
+  const mutate = async <T>(fn: () => Promise<T>): Promise<T | undefined> => {
+    setIsPending(true);
+    try {
+      return await fn();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : fallbackErrorMessage
+      );
+      return undefined;
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return { mutate, isPending };
+}


### PR DESCRIPTION
## Summary
Closes #142.

Client `fetch` mutations across ~10 components had no error handling
and/or no pending state, so a failed request either left the UI stuck
(a permanently-loading button) or failed silently with no user feedback.

- Add `useMutation` — a small shared hook (pending state + `toast.error` on thrown errors) that mutation handlers wrap their body in.
- Add `useLogout`, consolidating three copies of the same confirm+fetch+clear-session logout logic (`LogoutButton`,
  `CompanyProfileSectionContainer`, `ProfileSectionContainer`) that had no error handling if the logout request failed.
- Wire the hook into the components with real gaps: `AdminSavedSection` (the bug named in the issue), `CloseActionButton`, `CompanyStatsSection` (had a dead `isLoading` state that was never turned on), `CompanyViewProfileSectionContainer`, `PreviewProfileSectionContainer`, `ProfileSection`/`SettingsSection` (could get stuck in a loading state forever on a network error — `SettingsSection`'s error branch also showed a false success message), `QRCodeTab/CompanyTab`, `QRCodeTab/ScanTab`, and `CompanySavedProfilesSection.handleManualEntry`.

Components that already had solid try/catch + pending-state handling (e.g. `CompanyHistorySection`, most of `CompanySavedProfilesSection`, `QRCodeTab/ScanTab`'s scan handler) were left alone.