### PR TITLE
refactor: replace array-index keys with stable identity

### DIFF
--- a/src/components/Companies/CompanyProfile/CompanyHistorySection/index.tsx
+++ b/src/components/Companies/CompanyProfile/CompanyHistorySection/index.tsx
@@ -141,6 +141,8 @@ const CompanySavesSection = () => {
         style={{ scrollbarGutter: "stable" }}
       >
         {!historyData ? (
+          // fixed-count loading placeholders with no data yet, so there's no
+          // identity to key on besides position
           Array(3)
             .fill(1)
             .map((_, i) => (

--- a/src/components/Companies/FactSection/index.tsx
+++ b/src/components/Companies/FactSection/index.tsx
@@ -9,8 +9,11 @@ interface FactSectionProps {
 const FactSection: React.FC<FactSectionProps> = ({ facts }) => {
   return (
     <section className="my-5 flex flex-col space-y-2 text-sm leading-8 font-light sm:text-sm lg:px-10 lg:text-lg">
-      {facts.map((fact, i) => (
-        <div key={i} className="my-1 grid grid-cols-10 items-center">
+      {facts.map((fact) => (
+        <div
+          key={fact.description}
+          className="my-1 grid grid-cols-10 items-center"
+        >
           <fact.iconSrc className="left-0 fill-stone-500 text-2xl" />
           <div className="col-span-9 ml-3 text-left leading-5 text-black">
             {fact.description}

--- a/src/components/InputSelect/index.tsx
+++ b/src/components/InputSelect/index.tsx
@@ -47,8 +47,8 @@ const InputSelect: React.FC<InputSelectProps> = ({
         className={`h-14 w-full border border-white/35 bg-[#141414] px-2 py-1 text-sm text-white placeholder:text-white/35 focus:border-primary focus:ring-0 disabled:text-gray-600 ${className}`}
         {...rest}
       >
-        {options.map((option, index) => (
-          <option key={index} value={option}>
+        {options.map((option) => (
+          <option key={option} value={option}>
             {option}
           </option>
         ))}

--- a/src/components/QRCode/QRCodeTab/index.tsx
+++ b/src/components/QRCode/QRCodeTab/index.tsx
@@ -31,7 +31,7 @@ const QRCodeTab: React.FC<QRCodeTabProps> = ({
       <div className="flex justify-center">
         {tabTitles.map((title, index) => (
           <button
-            key={index}
+            key={title}
             className={`px-4 py-2 focus:outline-none ${
               selectedTab === index
                 ? "border-b-2 border-primary text-primary"

--- a/src/components/Schedule/index.tsx
+++ b/src/components/Schedule/index.tsx
@@ -173,7 +173,7 @@ const Schedule: React.FC<Props> = ({
           >
             {scheduleEvents[activeScheduleEventIndex].map((entry, index) => (
               <motion.tr
-                key={index}
+                key={entry.hour}
                 initial={{
                   opacity: 0,
                   x: activeScheduleEventIndex === 0 ? -50 : 50,


### PR DESCRIPTION
## Summary

Closes #143.

- `FactSection`: `key={i}` → `key={fact.description}`
- `InputSelect`: `key={index}` → `key={option}` (options are unique strings)
- `QRCodeTab/index.tsx`: `key={index}` → `key={title}` (tab titles are unique; `index` is still used for the click handler/active-tab comparison)
- `Schedule/index.tsx`: `key={index}` → `key={entry.hour}` (verified hours don't repeat within a single day's schedule in `edition/ScheduleDays.ts`)
- `CompanyHistorySection`'s skeleton loader: left the index key as-is with a comment explaining why — it's a fixed-count loading placeholder with no data yet, so there's no real identity to key on.

Note on scope: the original audit's "6 index-as-key sites" included `GiveawaySection`, which turned out to already be fixed by an unrelated prior refactor (`key={student.id}`) — so the actual count of live sites is 5, of which 4 get a real fix here and 1 (the skeleton loader) is a false positive, documented rather than changed.

The other half of the issue — a client component importing a type from a Prisma-backed module — is already resolved in the current codebase. No such import exists anymore, and `AGENTS.md` now explicitly documents type-only Prisma imports as acceptable practice.
