### PR TITLE
feat: add orphaned-file GC job

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,28 @@ Create two storage buckets:
 | avatars | public  |
 | cvs     | private |
 
+### Orphaned-file garbage collection
+
+Student media uploads are reconciled daily at 03:00 UTC. Objects are eligible
+only when they are under the app-managed avatar/CV prefixes, are unreferenced by
+`Student.avatar`/`Student.cv`, and are at least 48 hours old.
+
+1. In Supabase Vault, create `storage_gc_project_url` with the project URL and
+   `storage_gc_service_role_key` with the service-role key.
+2. Run [`supabase/storage-gc.sql`](./supabase/storage-gc.sql) manually in the
+   hosted Supabase SQL editor. Do not add the service-role key to the SQL file.
+3. Confirm the job exists with:
+
+   ```sql
+   select jobid, schedule, command, active
+   from cron.job
+   where jobname = 'storage-orphan-gc';
+   ```
+
+The job reads `storage.objects` but deletes through the Storage API; direct SQL
+deletion would remove only metadata and leave the billed blob behind. Failed API
+deletions remain in `storage.objects`, so the next daily run retries them.
+
 ---
 
 # Supabase CLI (Local Development)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ only when they are under the app-managed avatar/CV prefixes, are unreferenced by
    `storage_gc_service_role_key` with the service-role key.
 2. Run [`supabase/storage-gc.sql`](./supabase/storage-gc.sql) manually in the
    hosted Supabase SQL editor. Do not add the service-role key to the SQL file.
-3. Confirm the job exists with:
+   Its final query is non-destructive and returns the exact candidate set.
+3. Check every returned bucket/path against `Student.avatar`/`Student.cv`. The
+   installer intentionally does not schedule deletion.
+4. Only after confirming the dry run, run
+   [`supabase/storage-gc-enable.sql`](./supabase/storage-gc-enable.sql) manually.
+5. Confirm the job exists with:
 
    ```sql
    select jobid, schedule, command, active
@@ -99,6 +104,28 @@ only when they are under the app-managed avatar/CV prefixes, are unreferenced by
 The job reads `storage.objects` but deletes through the Storage API; direct SQL
 deletion would remove only metadata and leave the billed blob behind. Failed API
 deletions remain in `storage.objects`, so the next daily run retries them.
+
+Monitor runs and asynchronous deletion failures after 03:00 UTC:
+
+```sql
+select status, return_message, start_time, end_time
+from cron.job_run_details
+where jobid = (select jobid from cron.job where jobname = 'storage-orphan-gc')
+order by start_time desc
+limit 10;
+
+select id, status_code, timed_out, error_msg, created
+from net._http_response
+where timed_out or error_msg is not null or status_code not between 200 and 299
+order by created desc;
+
+select bucket_id, count(*)
+from public.storage_gc_candidates()
+group by bucket_id;
+```
+
+`pg_net` responses expire after six hours by default, so inspect them soon after
+the run. A candidate count that does not shrink indicates persistent failures.
 
 ---
 

--- a/supabase/storage-gc-enable.sql
+++ b/supabase/storage-gc-enable.sql
@@ -1,0 +1,8 @@
+-- Run manually only after reviewing the dry-run result from storage-gc.sql.
+-- This enables irreversible Storage API deletions at 03:00 UTC each day.
+
+select cron.schedule(
+  'storage-orphan-gc',
+  '0 3 * * *',
+  $job$select public.queue_orphaned_storage_gc();$job$
+);

--- a/supabase/storage-gc.sql
+++ b/supabase/storage-gc.sql
@@ -1,0 +1,101 @@
+-- Run manually in the hosted Supabase SQL editor after creating these Vault
+-- secrets (Dashboard > Integrations > Vault):
+--   storage_gc_project_url      = https://<project-ref>.supabase.co
+--   storage_gc_service_role_key = the project's service-role key
+--
+-- storage.objects is metadata only. This job reads it for reconciliation, then
+-- deletes through the Storage API so both the object and its metadata disappear.
+
+create extension if not exists pg_net with schema extensions;
+create extension if not exists pg_cron;
+
+create or replace function public.queue_orphaned_storage_gc()
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  candidate record;
+  project_url text;
+  service_role_key text;
+  request_headers jsonb;
+  queued_count integer := 0;
+begin
+  select decrypted_secret
+  into strict project_url
+  from vault.decrypted_secrets
+  where name = 'storage_gc_project_url';
+
+  select decrypted_secret
+  into strict service_role_key
+  from vault.decrypted_secrets
+  where name = 'storage_gc_service_role_key';
+
+  request_headers := jsonb_build_object(
+    'apikey', service_role_key,
+    'Authorization', 'Bearer ' || service_role_key
+  );
+
+  for candidate in
+    select objects.bucket_id, objects.name
+    from storage.objects as objects
+    where objects.created_at < now() - interval '48 hours'
+      and (
+        (
+          objects.bucket_id = 'avatars'
+          and objects.name ~ '^distribution/avatar/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+          and not exists (
+            select 1
+            from public."Student" as students
+            where students.avatar = replace(objects.name, 'distribution/avatar/', '')
+              or students.avatar = objects.name
+              or right(
+                split_part(students.avatar, '?', 1),
+                length('/avatars/' || objects.name)
+              ) = '/avatars/' || objects.name
+          )
+        )
+        or (
+          objects.bucket_id = 'cvs'
+          and objects.name ~ '^distribution/cv/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.pdf$'
+          and not exists (
+            select 1
+            from public."Student" as students
+            where students.cv = replace(
+                replace(objects.name, 'distribution/cv/', ''),
+                '.pdf',
+                ''
+              )
+              or students.cv = objects.name
+              or right(
+                split_part(students.cv, '?', 1),
+                length('/cvs/' || objects.name)
+              ) = '/cvs/' || objects.name
+          )
+        )
+      )
+    order by objects.created_at
+    -- ponytail: cap each run; raise it or run more often if backlog exceeds one day.
+    limit 1000
+  loop
+    perform net.http_delete(
+      url := rtrim(project_url, '/') || '/storage/v1/object/' ||
+        candidate.bucket_id || '/' || candidate.name,
+      headers := request_headers,
+      timeout_milliseconds := 5000
+    );
+    queued_count := queued_count + 1;
+  end loop;
+
+  return queued_count;
+end;
+$$;
+
+revoke all on function public.queue_orphaned_storage_gc() from public;
+
+select cron.schedule(
+  'storage-orphan-gc',
+  '0 3 * * *',
+  $job$select public.queue_orphaned_storage_gc();$job$
+);

--- a/supabase/storage-gc.sql
+++ b/supabase/storage-gc.sql
@@ -5,9 +5,66 @@
 --
 -- storage.objects is metadata only. This job reads it for reconciliation, then
 -- deletes through the Storage API so both the object and its metadata disappear.
+-- This installer does not enable deletion. Its final query is a required dry run;
+-- inspect every returned row before running storage-gc-enable.sql.
 
 create extension if not exists pg_net with schema extensions;
 create extension if not exists pg_cron;
+
+create or replace function public.storage_gc_candidates()
+returns table (
+  bucket_id text,
+  name text,
+  created_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select objects.bucket_id, objects.name, objects.created_at
+  from storage.objects as objects
+  where objects.created_at < now() - interval '48 hours'
+    and (
+      (
+        objects.bucket_id = 'avatars'
+        and objects.name ~ '^distribution/avatar/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        and not exists (
+          select 1
+          from public."Student" as students
+          where students.avatar = replace(objects.name, 'distribution/avatar/', '')
+            or students.avatar = objects.name
+            or right(
+              split_part(students.avatar, '?', 1),
+              length('/avatars/' || objects.name)
+            ) = '/avatars/' || objects.name
+        )
+      )
+      or (
+        objects.bucket_id = 'cvs'
+        and objects.name ~ '^distribution/cv/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.pdf$'
+        and not exists (
+          select 1
+          from public."Student" as students
+          where students.cv = replace(
+              replace(objects.name, 'distribution/cv/', ''),
+              '.pdf',
+              ''
+            )
+            or students.cv = objects.name
+            or right(
+              split_part(students.cv, '?', 1),
+              length('/cvs/' || objects.name)
+            ) = '/cvs/' || objects.name
+        )
+      )
+    )
+  order by objects.created_at
+  -- note: cap each run; raise it or run more often if backlog exceeds one day.
+  limit 1000
+$$;
+
+revoke all on function public.storage_gc_candidates() from public;
 
 create or replace function public.queue_orphaned_storage_gc()
 returns integer
@@ -38,46 +95,7 @@ begin
   );
 
   for candidate in
-    select objects.bucket_id, objects.name
-    from storage.objects as objects
-    where objects.created_at < now() - interval '48 hours'
-      and (
-        (
-          objects.bucket_id = 'avatars'
-          and objects.name ~ '^distribution/avatar/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-          and not exists (
-            select 1
-            from public."Student" as students
-            where students.avatar = replace(objects.name, 'distribution/avatar/', '')
-              or students.avatar = objects.name
-              or right(
-                split_part(students.avatar, '?', 1),
-                length('/avatars/' || objects.name)
-              ) = '/avatars/' || objects.name
-          )
-        )
-        or (
-          objects.bucket_id = 'cvs'
-          and objects.name ~ '^distribution/cv/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.pdf$'
-          and not exists (
-            select 1
-            from public."Student" as students
-            where students.cv = replace(
-                replace(objects.name, 'distribution/cv/', ''),
-                '.pdf',
-                ''
-              )
-              or students.cv = objects.name
-              or right(
-                split_part(students.cv, '?', 1),
-                length('/cvs/' || objects.name)
-              ) = '/cvs/' || objects.name
-          )
-        )
-      )
-    order by objects.created_at
-    -- ponytail: cap each run; raise it or run more often if backlog exceeds one day.
-    limit 1000
+    select * from public.storage_gc_candidates()
   loop
     perform net.http_delete(
       url := rtrim(project_url, '/') || '/storage/v1/object/' ||
@@ -94,8 +112,5 @@ $$;
 
 revoke all on function public.queue_orphaned_storage_gc() from public;
 
-select cron.schedule(
-  'storage-orphan-gc',
-  '0 3 * * *',
-  $job$select public.queue_orphaned_storage_gc();$job$
-);
+-- Required non-destructive dry run. Review every row before enabling the job.
+select * from public.storage_gc_candidates();


### PR DESCRIPTION
## Summary
- add pg_cron reconciliation for orphaned avatar and CV objects
- enforce 48-hour grace window, UUID/path scope, and 1,000-object cap
- delete through Supabase Storage API via pg_net using Vault credentials
- expose one shared candidate query for dry-run and deletion
- document cron/pg_net failure diagnostics

## Safety gate
1. Run supabase/storage-gc.sql manually. It installs functions but does not schedule deletion; its final query returns the exact candidates without deleting anything.
2. Review every returned bucket/path against Student.avatar and Student.cv.
3. Only after confirming the dry run, run supabase/storage-gc-enable.sql to schedule daily deletion.

SQL was not executed by this task because repository instructions prohibit agents from running SQL. Production activation therefore remains blocked on the required human dry run.

## Verification
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm test (19 files, 51 tests)
- pnpm typecheck

Rebased onto current dev, including the merged React Toastify consolidation; no SweetAlert dependency or usage remains.