### PR TITLE
fix: use React Toastify for company notifications

### DIFF
--- a/src/components/CompanyAdminSection/index.tsx
+++ b/src/components/CompanyAdminSection/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useRef, useState } from "react";
-import Swal from "sweetalert";
+import { toast } from "react-toastify";
 
 import { httpClient } from "@/lib/http/client";
 import { useMutation } from "@/hooks/useMutation";
@@ -37,7 +37,7 @@ const CompanyRow: React.FC<CompanyRowProps> = ({ company, onSaved }) => {
         }
       );
       onSaved(updated);
-      Swal("Sucesso", "Empresa atualizada.", "success");
+      toast.success("Empresa atualizada.");
     });
 
   return (
@@ -119,7 +119,7 @@ const CompanyAdminSection: React.FC<CompanyAdminSectionProps> = ({
       );
       setCompanies((prev) => [...prev, created]);
       if (nameRef.current) nameRef.current.value = "";
-      Swal("Sucesso", "Empresa criada.", "success");
+      toast.success("Empresa criada.");
     });
   };
 


### PR DESCRIPTION
## Summary
- replace the remaining SweetAlert import in CompanyAdminSection with React Toastify
- preserve existing success messages for company create/update
- keep the repository on its single notification library

No package.json or pnpm-lock.yaml changes.

## Verification
- pnpm install --frozen-lockfile (removed local SweetAlert packages)
- pnpm lint
- pnpm test (17 files, 41 tests)
- pnpm typecheck

Split from #200 to keep the storage GC feature scoped.