### PR TITLE
fix: pass real seconds to QR action token expiresIn

### DIFF
--- a/src/application/services/actionService.test.ts
+++ b/src/application/services/actionService.test.ts
@@ -32,3 +32,16 @@ test("does not sign a QR token for a missing action", async () => {
   await expect(getActionQrCode("missing")).resolves.toBeNull();
   expect(signJwt).not.toHaveBeenCalled();
 });
+
+test("signs the QR token with a real ~30s expiry, not 30000 seconds", async () => {
+  vi.mocked(findActionById).mockResolvedValue({
+    id: "action-1",
+  } as Awaited<ReturnType<typeof findActionById>>);
+
+  await getActionQrCode("action-1");
+
+  expect(signJwt).toHaveBeenCalledWith(
+    expect.objectContaining({ id: "action-1" }),
+    expect.objectContaining({ expiresIn: 30 })
+  );
+});

--- a/src/application/services/actionService.ts
+++ b/src/application/services/actionService.ts
@@ -60,7 +60,10 @@ export async function getActionQrCode(id: string) {
         { id, timestamp },
         {
           algorithm: "HS256",
-          expiresIn: config.constants.actionQrCodeRefreshRateMs * 2,
+          // jsonwebtoken's numeric `expiresIn` is seconds, not ms - dividing
+          // by 1000 here previously made this token valid for ~8.3 hours
+          // instead of the intended 30s anti-replay window.
+          expiresIn: (config.constants.actionQrCodeRefreshRateMs * 2) / 1000,
         }
       ),
   };


### PR DESCRIPTION
`getActionQrCode()` passed `actionQrCodeRefreshRateMs * 2` (a millisecond value) straight into `jsonwebtoken`'s numeric `expiresIn`, which is interpreted as seconds — making the QR action token valid for ~8.3 hours instead of 30 seconds. Since scans earn giveaway points, a screenshotted code was replayable for hours. Fixed by dividing by 1000; `jsonwebtoken`'s own `exp` check (already active in `verifyJwt`) now enforces the 30s window with no extra code needed.

Refs #212.