### PR TITLE
build: add BuildKit cache mount for pnpm store in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,10 @@ COPY prisma ./prisma
 # BuildKit cache mount lets pnpm skip re-downloading unchanged packages —
 # `store-dir` is pinned explicitly so pnpm actually writes into the mounted
 # path instead of whatever its platform default would otherwise resolve to.
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+# `sharing=locked` serializes access to the mount so two overlapping builds
+# on the same host (e.g. Coolify deploying two branches at once) can't race
+# on writes to the store.
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store,sharing=locked \
   if [ -f pnpm-lock.yaml ]; then \
     pnpm config set store-dir /pnpm/store && \
     pnpm install --frozen-lockfile; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,14 @@ WORKDIR /app
 COPY package.json package-lock.json* pnpm-lock.yaml* ./
 COPY prisma ./prisma
 
-# Install dependencies based on the preferred package manager
-RUN \
+# Install dependencies based on the preferred package manager.
+# The pnpm store is content-addressable, so persisting it across builds via a
+# BuildKit cache mount lets pnpm skip re-downloading unchanged packages —
+# `store-dir` is pinned explicitly so pnpm actually writes into the mounted
+# path instead of whatever its platform default would otherwise resolve to.
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
   if [ -f pnpm-lock.yaml ]; then \
+    pnpm config set store-dir /pnpm/store && \
     pnpm install --frozen-lockfile; \
   elif [ -f package-lock.json ]; then \
     npm ci; \


### PR DESCRIPTION
## Summary
- Docker builds currently run a plain `pnpm install --frozen-lockfile` in the `deps` stage with no persistent cache, so every deploy re-downloads all of node_modules (~1.4GB, including native binaries like sharp, Prisma engines, and Sentry tooling) from scratch even when only one package changed.
- Adds a BuildKit cache mount (`--mount=type=cache,id=pnpm,target=/pnpm/store`) to the `deps` stage's install step, combined with `pnpm config set store-dir /pnpm/store` so pnpm's content-addressable store actually persists at that mounted path across builds on the self-hosted VPS (Coolify), instead of re-fetching unchanged packages every deploy.
- No other stages were restructured — this only touches the `deps` stage's install `RUN` step.

Closes #205

## Verification
- `pnpm lint` — clean, no issues in touched files.
- `pnpm typecheck` — clean.
- `docker build --target deps` — builds successfully.
- Manually verified the cache mount actually works: forced the install layer to re-run (via a temporary cache-busting `ARG`, since layer invalidation is otherwise needed to observe reuse) while keeping the persistent `/pnpm/store` mount intact. Result: pnpm reported `reused 1146/1148` packages, `downloaded 0`, and the install step finished in ~15s versus ~75-90s on a cold store. Confirms the intended bandwidth/build-time savings on repeat builds where the lockfile is largely unchanged.
- Did not measure real-world build-time improvement on the actual Coolify/VPS host — that depends on the BuildKit cache directory persisting there across deploys, which this PR can't verify locally.

## Note for reviewers
Per issue #205's "Dependencies" note, this shares the `deps`/`builder` Dockerfile stages with issue #206 (migrate build split), so it may be worth reviewing together. #206 itself is out of scope for this PR.