### PR TITLE
fix: don't fail the build on a Sentry release/upload error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -53,4 +53,12 @@ module.exports = withSentryConfig(withPWA(nextConfig), {
   sourcemaps: {
     deleteSourcemapsAfterUpload: true,
   },
+  // The plugin's default on a release/upload failure is to throw and fail
+  // the whole build — too strict for source maps, which are an
+  // observability nicety, not something that should block a deploy
+  // (especially against a self-hosted backend like GlitchTip, whose API
+  // doesn't fully mirror Sentry's release-management endpoints).
+  errorHandler: (err) => {
+    console.warn("Sentry release/source-map upload failed:", err);
+  },
 });


### PR DESCRIPTION
## Summary
- The Coolify deploy for `dev` is failing at the `pnpm run build` step inside the Docker `builder` stage, exit code 1 with no captured error text.
- `next.config.js`'s `withSentryConfig()` call sets no `errorHandler`. Per `@sentry/bundler-plugins`'s own docs: "By default, the plugin will simply throw an error, thereby stopping the bundling process" on a release-creation/source-map-upload failure.
- Since this repo now points `SENTRY_URL` at a self-hosted GlitchTip instance (#... self-host-glitchtip work), and GlitchTip doesn't fully implement Sentry's release-management API, a failure there is a very plausible way for this to hard-fail the whole build.
- Adds an `errorHandler` that logs a warning instead of throwing — source map upload is an observability nicety, not something that should block a deploy.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `npx eslint next.config.js` clean
- [ ] Confirm this actually resolves the Coolify build failure once merged/deployed — could not reproduce locally (needs the real Docker build args/secrets against the GlitchTip instance)