### PR TITLE
fix: guide students to confirm their email after signup

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -8,13 +8,13 @@ export const POST = defineHandler({
   auth: "public",
   schema: signUpSchema,
   handler: async ({ body }) => {
-    await signUpUser({
+    const { requiresEmailConfirmation } = await signUpUser({
       email: body.email,
       password: body.password,
       role: "STUDENT",
     });
     return NextResponse.json(
-      { message: "Signup successfully" },
+      { message: "Signup successfully", requiresEmailConfirmation },
       { status: 201 }
     );
   },

--- a/src/application/services/authApplicationService.ts
+++ b/src/application/services/authApplicationService.ts
@@ -20,14 +20,38 @@ import {
   upsertUser,
 } from "../repositories/userRepository";
 
+// Self-hosted GoTrue occasionally returns an error body with none of the
+// msg/message/error/error_description fields supabase-js looks for (e.g. an
+// infra-level failure upstream of GoTrue itself); its client then falls back
+// to JSON.stringify()-ing the (often empty) body, producing an opaque "{}"
+// that isn't useful to show a user. Fall back to a fixed message instead of
+// letting that leak through to the UI.
+function usableAuthErrorMessage(message: string | undefined, fallback: string) {
+  const trimmed = message?.trim();
+  if (!trimmed || trimmed.startsWith("{")) return fallback;
+  return trimmed;
+}
+
 async function createSupabaseAuthUser(email: string, password: string) {
   const supabase = await createSupabaseServerClient();
   const { data, error } = await supabase.auth.signUp({ email, password });
   if (error || !data.user)
-    throw new HttpError(error?.message || "Unable to sign up", 400);
-  if (!data.session)
-    await supabase.auth.signInWithPassword({ email, password });
-  return data.user;
+    throw new HttpError(
+      usableAuthErrorMessage(error?.message, "Unable to sign up"),
+      400
+    );
+  // No session means "Confirm email" is on and this identity hasn't
+  // confirmed yet - signInWithPassword() is expected to fail in that case,
+  // so its result only tells us whether a session actually got established.
+  let hasSession = Boolean(data.session);
+  if (!hasSession) {
+    const { data: signInData } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    hasSession = Boolean(signInData.session);
+  }
+  return { user: data.user, requiresEmailConfirmation: !hasSession };
 }
 
 // Used when an admin creates a Student/Employee account on someone else's
@@ -46,7 +70,10 @@ export async function createSupabaseAuthUserAsAdmin(
     email_confirm: true,
   });
   if (error || !data.user)
-    throw new HttpError(error?.message || "Unable to create account", 400);
+    throw new HttpError(
+      usableAuthErrorMessage(error?.message, "Unable to create account"),
+      400
+    );
   return data.user;
 }
 
@@ -103,9 +130,12 @@ export async function signUpUser(input: {
   password: string;
   role: "STUDENT" | "EMPLOYEE";
 }) {
-  const user = await createSupabaseAuthUser(input.email, input.password);
+  const { user, requiresEmailConfirmation } = await createSupabaseAuthUser(
+    input.email,
+    input.password
+  );
   await upsertUser({ id: user.id, email: input.email, role: input.role });
-  return user;
+  return { user, requiresEmailConfirmation };
 }
 
 type SessionUser = NonNullable<Awaited<ReturnType<typeof findUserSessionById>>>;
@@ -189,7 +219,7 @@ export async function signUpEmployee(input: {
 }) {
   const company = await findCompanyByCode(input.companyCode);
   if (!company) throw new HttpError("Invalid company code", 404);
-  const user = await createSupabaseAuthUser(input.email, input.password);
+  const { user } = await createSupabaseAuthUser(input.email, input.password);
   try {
     await withTransaction(async (tx) => {
       await upsertUser(

--- a/src/client/api/auth.ts
+++ b/src/client/api/auth.ts
@@ -8,11 +8,10 @@ export async function createAccount(data: {
   password: string | null;
 }) {
   try {
-    await httpClient.post("/auth/signup", {
-      email: data.email,
-      password: data.password,
-    });
-    return true;
+    return await httpClient.post<{ requiresEmailConfirmation: boolean }>(
+      "/auth/signup",
+      { email: data.email, password: data.password }
+    );
   } catch (error) {
     return error instanceof Error ? error : new Error("Network error");
   }

--- a/src/components/SignUp/FinalStep/index.tsx
+++ b/src/components/SignUp/FinalStep/index.tsx
@@ -138,6 +138,18 @@ const FinalStep: FunctionComponent<FinalStepProps> = ({ data, setData }) => {
           toast.error("Ocorreu um erro ao criar a conta.");
           return setLoading(false);
         }
+
+        // "Confirm email" is on and this account hasn't been confirmed yet,
+        // so Supabase didn't hand back a session - none of the steps below
+        // (uploads, profile creation) can run without one. Stop here instead
+        // of continuing on to confusing "Unauthorized" failures.
+        if (account.requiresEmailConfirmation) {
+          toast.info(
+            "Criámos a tua conta! Verifica o teu email institucional, confirma a conta e depois inicia sessão para continuares o registo."
+          );
+          router.push("/login");
+          return setLoading(false);
+        }
       }
 
       const avatarUrl = await handleAvatarUpload();


### PR DESCRIPTION
## Summary
- Diagnosed three auth bugs reported on `fallstack.nei-isep.org`: AuthNEI OAuth ("Provider custom:authnei could not be found"), a signup that silently stalls with a 401 on `/api/auth/session`, and a signup that returns a 400 with an opaque `"{}"` error body.
- The AuthNEI provider error is a Supabase-side config gap (the `custom:authnei` OIDC provider isn't registered on the self-hosted GoTrue instance) — not fixable in this repo.
- The other two share a root cause: `signUpUser()`/`createSupabaseAuthUser()` discarded whether the post-signup `signInWithPassword()` fallback actually established a session, and the route always reported success regardless. When "Confirm email" leaves no session behind, the signup wizard (`FinalStep`) pressed on into avatar/CV upload and profile creation with no session, which failed silently. Separately, when self-hosted GoTrue returns an error body Supabase's client can't extract a message from, it falls back to `JSON.stringify()`-ing the body — the literal `"{}"` seen in the report — which was passed straight through to the user.
- `signUpUser`/`createSupabaseAuthUser` now report `requiresEmailConfirmation`, threaded through the signup route and `createAccount()`; the signup wizard shows a clear "check your email" message and sends the student to `/login` instead of continuing without a session. Added a fallback for unusable Supabase error messages so a bare `"{}"` never reaches the UI again.

## Test plan
- [x] `pnpm lint` on touched files
- [x] `pnpm typecheck`
- [x] `pnpm test` (existing suite, unmodified — all pass)
- [x] Hit `POST /api/auth/signup` against the dev server to confirm the validation path still works
- [ ] Manual click-through of the confirm-email flow against a live Supabase project (no local Supabase/Docker stack available in this environment to verify end-to-end)