### PR TITLE
fix: register AuthNEI under GoTrue's built-in keycloak provider id

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -7,8 +7,9 @@ import { createClient as createSupabaseServerClient } from "@/utils/supabase/ser
 
 import { sanitizeNext } from "./sanitizeNext";
 
-// Supabase-constructed OAuth callback URL, used by the AuthNEI
-// ("custom:authnei") sign-in flow — exchanges the `code` query param for a
+// Supabase-constructed OAuth callback URL, used by the AuthNEI (registered
+// under GoTrue's built-in "keycloak" provider id - see config/index.ts's
+// authneiProvider) sign-in flow — exchanges the `code` query param for a
 // session via exchangeCodeForSession. This is a different flow from
 // app/auth/confirm/route.ts (which only handles OTP email-link
 // confirmation), but lives alongside it outside the (auth)/api conventions

--- a/src/components/AuthNeiButton/index.tsx
+++ b/src/components/AuthNeiButton/index.tsx
@@ -37,10 +37,11 @@ const AuthNeiButton: React.FC<AuthNeiButtonProps> = ({
     redirectTo.searchParams.set("next", next);
 
     const { error } = await supabase.auth.signInWithOAuth({
-      // "custom:authnei" is Supabase's custom OIDC provider id for AuthNEI
-      // (NEI's self-hosted Zitadel instance) — it isn't part of the SDK's
-      // built-in Provider union, hence the cast.
-      provider: config.constants.authneiProvider as unknown as Provider,
+      // GoTrue has no arbitrarily-named external provider mechanism, so
+      // AuthNEI (NEI's self-hosted Zitadel instance) is registered under
+      // the built-in "keycloak" provider id, which is generic OIDC
+      // discovery under the hood — not literally Keycloak.
+      provider: config.constants.authneiProvider as Provider,
       options: { redirectTo: redirectTo.toString() },
     });
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -30,10 +30,14 @@ const config = {
   constants: {
     actionQrCodeRefreshRateMs: 15 * 1000, // 15 seconds
     neiContactEmail: "info@nei-isep.org",
-    // Supabase custom OIDC provider id for AuthNEI (NEI's self-hosted
-    // Zitadel instance), configured via the Supabase dashboard. Not a
-    // secret — safe to reference directly as a string constant.
-    authneiProvider: "custom:authnei",
+    // GoTrue's built-in "keycloak" external provider id, repurposed for
+    // AuthNEI (NEI's self-hosted Zitadel instance) - that provider is just
+    // generic OIDC-discovery under the hood (GOTRUE_EXTERNAL_KEYCLOAK_URL
+    // pointing at Zitadel's issuer), not literally Keycloak. GoTrue has no
+    // mechanism for an arbitrarily-named external provider, so it's this
+    // fixed id rather than something AuthNEI-specific. Not a secret - safe
+    // to reference directly as a string constant.
+    authneiProvider: "keycloak",
   },
 };
 


### PR DESCRIPTION
## Summary
- The app requested `provider: "custom:authnei"` from Supabase Auth, but self-hosted GoTrue has no mechanism to register an external OAuth provider under an arbitrary name via env vars — only its fixed built-in list (`google`, `github`, `keycloak`, ...). Configuring `GOTRUE_EXTERNAL_KEYCLOAK_*` on the infra side registers the provider as `"keycloak"`, not `"custom:authnei"`, so `signInWithOAuth` always failed with `Unsupported provider: Provider custom:authnei could not be found`, regardless of whether the client ID/secret were correct.
- Repurposes GoTrue's built-in `"keycloak"` provider id for AuthNEI instead — its implementation is generic OIDC-discovery under the hood (via `GOTRUE_EXTERNAL_KEYCLOAK_URL` pointing at the issuer), so it works the same against Zitadel as it would against actual Keycloak. Updated `config/index.ts`, `AuthNeiButton`, and the OAuth callback route's comments to reflect this and avoid future confusion about why a "keycloak" provider id is being used for a Zitadel-backed flow.
- Also drops the now-unnecessary `as unknown as Provider` double-cast in `AuthNeiButton`, since `"keycloak"` is a real member of `@supabase/supabase-js`'s `Provider` union (unlike the old made-up `"custom:authnei"` string).

## Test plan
- [x] `pnpm lint` on touched files
- [x] `pnpm typecheck`
- [x] `pnpm test` (existing suite, unmodified — all pass)
- [ ] Live click-through of AuthNEI sign-in against a real Supabase project (no local Supabase/Docker stack available in this environment) — still depends on the infra side actually setting `GOTRUE_EXTERNAL_KEYCLOAK_ENABLED=true` with correct `CLIENT_ID`/`SECRET`/`REDIRECT_URI`/`URL` (issuer) and recreating the `supabase-auth` container.