### PR TITLE
fix: revert AuthNEI provider id back to custom:authnei

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -8,9 +8,9 @@ import { createClient as createSupabaseServerClient } from "@/utils/supabase/ser
 import { sanitizeNext } from "./sanitizeNext";
 
 // Supabase-constructed OAuth callback URL, used by the AuthNEI (registered
-// under GoTrue's built-in "keycloak" provider id - see config/index.ts's
-// authneiProvider) sign-in flow — exchanges the `code` query param for a
-// session via exchangeCodeForSession. This is a different flow from
+// as a GoTrue custom OIDC provider - see config/index.ts's authneiProvider)
+// sign-in flow — exchanges the `code` query param for a session via
+// exchangeCodeForSession. This is a different flow from
 // app/auth/confirm/route.ts (which only handles OTP email-link
 // confirmation), but lives alongside it outside the (auth)/api conventions
 // for the same reason: Supabase itself constructs this URL.

--- a/src/components/AuthNeiButton/index.tsx
+++ b/src/components/AuthNeiButton/index.tsx
@@ -37,10 +37,10 @@ const AuthNeiButton: React.FC<AuthNeiButtonProps> = ({
     redirectTo.searchParams.set("next", next);
 
     const { error } = await supabase.auth.signInWithOAuth({
-      // GoTrue has no arbitrarily-named external provider mechanism, so
-      // AuthNEI (NEI's self-hosted Zitadel instance) is registered under
-      // the built-in "keycloak" provider id, which is generic OIDC
-      // discovery under the hood — not literally Keycloak.
+      // "custom:authnei" is GoTrue's DB-backed custom OIDC provider id for
+      // AuthNEI (NEI's self-hosted Zitadel instance) — registered via
+      // GoTrue's admin API, not a fixed built-in name, hence the cast
+      // (it isn't part of the SDK's Provider union).
       provider: config.constants.authneiProvider as Provider,
       options: { redirectTo: redirectTo.toString() },
     });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -30,14 +30,18 @@ const config = {
   constants: {
     actionQrCodeRefreshRateMs: 15 * 1000, // 15 seconds
     neiContactEmail: "info@nei-isep.org",
-    // GoTrue's built-in "keycloak" external provider id, repurposed for
-    // AuthNEI (NEI's self-hosted Zitadel instance) - that provider is just
-    // generic OIDC-discovery under the hood (GOTRUE_EXTERNAL_KEYCLOAK_URL
-    // pointing at Zitadel's issuer), not literally Keycloak. GoTrue has no
-    // mechanism for an arbitrarily-named external provider, so it's this
-    // fixed id rather than something AuthNEI-specific. Not a secret - safe
-    // to reference directly as a string constant.
-    authneiProvider: "keycloak",
+    // GoTrue's DB-backed custom OAuth/OIDC provider id for AuthNEI (NEI's
+    // self-hosted Zitadel instance): any "custom:<id>" provider name is
+    // resolved against a provider registered via GoTrue's admin API
+    // (POST /admin/custom-providers, gated by GOTRUE_CUSTOM_OAUTH_ENABLED/
+    // GOTRUE_CUSTOM_OAUTH_MAX_PROVIDERS), which does real OIDC discovery
+    // against whatever issuer URL it's given - unlike GoTrue's fixed-name
+    // built-in providers (e.g. "keycloak", which hardcodes Keycloak-specific
+    // endpoint paths and doesn't work against a non-Keycloak issuer like
+    // Zitadel). Not a secret - safe to reference directly as a string
+    // constant; the actual client id/secret/issuer live in GoTrue's config,
+    // not here.
+    authneiProvider: "custom:authnei",
   },
 };
 


### PR DESCRIPTION
## Summary

Corrects a wrong fix from #260. That PR changed the AuthNEI provider id from `"custom:authnei"` to GoTrue's built-in `"keycloak"` provider, on the assumption its OIDC config is generic issuer-discovery-based. That assumption was wrong and is now disproved by a live test: GoTrue redirected to `https://auth.dev.nei-isep.org/protocol/openid-connect/auth`, and Zitadel 404'd (`{"code":5,"message":"Not Found"}`) because that path doesn't exist on Zitadel.

Checked GoTrue's actual source (`supabase/auth` on GitHub) this time before changing anything:
- `internal/api/provider/keycloak.go`'s `NewKeycloakProvider` hardcodes Keycloak-specific endpoint paths (`/protocol/openid-connect/auth`, `/protocol/openid-connect/token`, `/protocol/openid-connect/userinfo`) onto the configured URL — it does **not** do `.well-known/openid-configuration` discovery. It only works against an actual Keycloak instance.
- `internal/api/external.go`'s provider resolver special-cases any `"custom:"`-prefixed name and resolves it via `loadCustomProvider()` against a provider registered through GoTrue's own admin API (`internal/api/custom_oauth_admin.go`, `POST /admin/custom-providers`), gated by `GOTRUE_CUSTOM_OAUTH_ENABLED`/`GOTRUE_CUSTOM_OAUTH_MAX_PROVIDERS`. That mechanism does real OIDC discovery against an arbitrary issuer URL — the right fit for Zitadel.

So `"custom:authnei"` was correct all along. The original "Unsupported provider" error was because no provider had actually been registered under that identifier via GoTrue's admin API yet — not because the identifier itself was wrong.

Reverts `config/index.ts`'s `authneiProvider` back to `"custom:authnei"` and fixes up the comments in `AuthNeiButton` and the OAuth callback route to describe the real mechanism (and why it's not just a `GOTRUE_EXTERNAL_*` env var away).

## Infra follow-up (not part of this PR)
Registering the actual `custom:authnei` provider requires calling GoTrue's admin API directly (not a docker-compose env var), e.g.:
```
POST <supabase-url>/auth/v1/admin/custom-providers
Authorization: Bearer <service_role key>

{
  "provider_type": "oidc",
  "identifier": "custom:authnei",
  "name": "AuthNEI",
  "client_id": "<zitadel client id>",
  "client_secret": "<zitadel client secret>",
  "issuer": "https://auth.dev.nei-isep.org",
  "scopes": ["openid", "email", "profile"]
}
```
after confirming `GOTRUE_CUSTOM_OAUTH_ENABLED=true` and `GOTRUE_CUSTOM_OAUTH_MAX_PROVIDERS >= 1` are set. This admin API was added to GoTrue relatively recently (~Feb 2026) — worth confirming the deployed GoTrue image is new enough to have it before relying on this.

## Test plan
- [x] `pnpm lint` on touched files
- [x] `pnpm typecheck`
- [x] `pnpm test` (existing suite, unmodified — all pass)
- [ ] Live click-through against a real Supabase/GoTrue instance with `custom:authnei` actually registered via the admin API — not done in this environment, and depends entirely on the infra follow-up above.