### PR TITLE
fix: send students with no profile back to signup

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -48,14 +48,18 @@ const LoginPage: React.FC = () => {
     if (await logIn(email, password)) {
       await session.fetchSession();
 
-      // Redirect based on user role
+      // Redirect based on user role. A STUDENT can be logging in with no
+      // Student row yet - e.g. they had to confirm their email before the
+      // signup wizard could finish creating the profile - so send them back
+      // into the wizard to complete it instead of the homepage.
       if (session.user?.role === "EMPLOYEE") {
         router.push("/dashboard");
-      } else if (
-        session.user?.role === "STUDENT" &&
-        session.user?.student?.code
-      ) {
-        router.push(`/student/${session.user.student.code}`);
+      } else if (session.user?.role === "STUDENT") {
+        router.push(
+          session.user.student
+            ? `/student/${session.user.student.code}`
+            : "/signup"
+        );
       } else {
         router.push("/");
       }

--- a/src/components/Profile/UserButton/index.tsx
+++ b/src/components/Profile/UserButton/index.tsx
@@ -10,12 +10,16 @@ interface UserButtonProps {
 }
 
 const UserButton: React.FC<UserButtonProps> = ({ user }) => {
+  // A STUDENT-role session can exist with no Student row yet - e.g. the
+  // Supabase account was created but the signup wizard was abandoned or
+  // interrupted before the profile step. Route back into the wizard to
+  // finish it instead of a dead link.
   const profileUrl =
     user.role === "EMPLOYEE"
       ? "/dashboard"
-      : !!user.student
+      : user.student
         ? "/student/" + user.student.code
-        : "";
+        : "/signup";
 
   return (
     <Link


### PR DESCRIPTION
## Summary

Root-caused via GoTrue logs from a real manual signup test: a `STUDENT` can legitimately end up logged in with a `User` row but no `Student` row yet, and until now there was no way back into the wizard to finish.

- `LoginPage`'s post-login redirect (`src/app/(auth)/login/page.tsx`) had a case for `EMPLOYEE` and for a `STUDENT` *with* a profile, but nothing for a `STUDENT` with none — it fell through to `/`. That's exactly what happens after PR #259's "Confirm email" flow: create account → told to check email → log in → **land on the homepage with an incomplete account**, since email confirmation always defers profile creation to a step that already returned early.
- `UserButton` (the profile icon in the top bar) computed an empty `href` for the same STUDENT-without-profile state, so even the profile icon was a dead end — no way back into the wizard at all.

Both now route a `STUDENT` with no `student` profile to `/signup`, which already knows how to resume from an existing session (`FinalStep` checks `getSession()` and skips re-creating the Supabase account) rather than failing on a duplicate-account error.

## Test plan
- [x] `pnpm lint` on touched files
- [x] `pnpm typecheck`
- [x] `pnpm test` (existing suite, unmodified — all pass)
- [ ] Live click-through of confirm-email → login → land in `/signup` → click profile icon mid-wizard — not verified in this environment (needs a real Supabase session), but directly traced against real GoTrue logs showing exactly this account state occurring in production.