### PR TITLE
feat: add SuperAdmin/Admin role tiers

### DIFF
--- a/prisma/migrations/20260728170000_add_admin_roles/migration.sql
+++ b/prisma/migrations/20260728170000_add_admin_roles/migration.sql
@@ -1,0 +1,15 @@
+-- CreateEnum
+CREATE TYPE "AdminRole" AS ENUM ('ADMIN', 'SUPER_ADMIN');
+
+-- AlterTable: add the new columns first, backfill from the boolean being
+-- replaced, then drop it - existing isAdmin=true users become ADMIN (the
+-- narrower tier; nobody is auto-promoted to SUPER_ADMIN by this migration).
+ALTER TABLE "User"
+  ADD COLUMN     "adminRole" "AdminRole",
+  ADD COLUMN     "name" TEXT,
+  ALTER COLUMN "role" DROP NOT NULL,
+  ALTER COLUMN "role" DROP DEFAULT;
+
+UPDATE "User" SET "adminRole" = 'ADMIN' WHERE "isAdmin" = true;
+
+ALTER TABLE "User" DROP COLUMN "isAdmin";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,15 +9,24 @@ datasource db {
 }
 
 model User {
-  id      String  @id @default(uuid()) @db.Uuid
-  email   String  @unique
-  role    Role    @default(STUDENT)
-  isAdmin Boolean @default(false)
+  id        String     @id @default(uuid()) @db.Uuid
+  // Null for an admin-only account (no Student/Employee profile - see
+  // adminRole below). Non-null for every self-service/admin-provisioned
+  // Student or Employee account.
+  role      Role?
+  email     String     @unique
+  // Null means not an admin. Orthogonal to role: an admin account has no
+  // Student/Employee profile and role is null, it isn't a STUDENT/EMPLOYEE
+  // that also happens to be an admin.
+  adminRole AdminRole?
+  // Display name for an admin-only account - Student/Employee have their
+  // own `name` on their respective profile table instead.
+  name      String?
   // Gates a Student/Employee's ability to log in - deactivating the User
   // deactivates both, since Student/Employee are 1:1 with User on this id.
-  active    Boolean  @default(true)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  active    Boolean    @default(true)
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
 
   student   Student?
   employee  Employee?
@@ -181,6 +190,14 @@ model SavedStudent {
 enum Role {
   STUDENT
   EMPLOYEE
+}
+
+enum AdminRole {
+  // Manages Students/Employees and the rest of today's admin backoffice.
+  ADMIN
+  // Everything ADMIN can do, plus creating/editing/deactivating other admin
+  // accounts.
+  SUPER_ADMIN
 }
 
 enum Tier {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Role, Tier, Year } from "@prisma/client";
+import { AdminRole, PrismaClient, Role, Tier, Year } from "@prisma/client";
 
 import { actions } from "@/edition/actions";
 import { createAdminClient } from "@/utils/supabase/admin";
@@ -96,8 +96,9 @@ async function seedAdmin() {
     data: {
       id: supabaseUser.id,
       email,
-      role: Role.EMPLOYEE,
-      isAdmin: true,
+      role: null,
+      name: "Admin",
+      adminRole: AdminRole.SUPER_ADMIN,
     },
   });
 

--- a/src/app/(admin)/admins/[id]/edit/page.tsx
+++ b/src/app/(admin)/admins/[id]/edit/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from "next/navigation";
+
+import AdminAccountForm from "@/components/AdminAccountForm";
+import { toAdminAccountDto } from "@/application/dto/adminAccountDto";
+import { getAdminAccountById } from "@/application/services/adminAccountService";
+import getServerSession from "@/application/services/sessionService";
+
+interface EditAdminPageProps {
+  params: Promise<{ id: string }>;
+}
+
+const EditAdminPage = async ({ params }: EditAdminPageProps) => {
+  const session = await getServerSession();
+  if (!session || session.adminRole !== "SUPER_ADMIN") notFound();
+
+  const { id } = await params;
+  const admin = await getAdminAccountById(id);
+  if (!admin) notFound();
+
+  return (
+    <section className="flex flex-col gap-6 p-8">
+      <h1 className="text-2xl font-bold text-gray-800">Editar admin</h1>
+      <AdminAccountForm admin={toAdminAccountDto(admin)} />
+    </section>
+  );
+};
+
+export default EditAdminPage;

--- a/src/app/(admin)/admins/new/page.tsx
+++ b/src/app/(admin)/admins/new/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from "next/navigation";
+
+import AdminAccountForm from "@/components/AdminAccountForm";
+import getServerSession from "@/application/services/sessionService";
+
+const NewAdminPage = async () => {
+  const session = await getServerSession();
+  if (!session || session.adminRole !== "SUPER_ADMIN") notFound();
+
+  return (
+    <section className="flex flex-col gap-6 p-8">
+      <h1 className="text-2xl font-bold text-gray-800">Adicionar admin</h1>
+      <AdminAccountForm />
+    </section>
+  );
+};
+
+export default NewAdminPage;

--- a/src/app/(admin)/admins/page.tsx
+++ b/src/app/(admin)/admins/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import {
+  parseAdminListParams,
+  type AdminListSearchParams,
+} from "@/lib/adminListParams";
+import AdminDeleteButton from "@/components/AdminDeleteButton";
+import AdminToggleButton from "@/components/AdminToggleButton";
+import DataTable, { type DataTableColumn } from "@/components/DataTable";
+import { toAdminAccountDto } from "@/application/dto/adminAccountDto";
+import { listAdminsForAdmin } from "@/application/services/adminAccountService";
+import getServerSession from "@/application/services/sessionService";
+
+const PAGE_SIZE = 20;
+
+interface AdminsPageProps {
+  searchParams: AdminListSearchParams;
+}
+
+type AdminRow = ReturnType<typeof toAdminAccountDto>;
+
+const columns: DataTableColumn<AdminRow>[] = [
+  { key: "name", header: "Nome", render: (a) => a.name, sortable: true },
+  { key: "email", header: "Email", render: (a) => a.email, sortable: true },
+  {
+    key: "adminRole",
+    header: "Tipo",
+    render: (a) => (a.adminRole === "SUPER_ADMIN" ? "Super Admin" : "Admin"),
+  },
+];
+
+const AdminsPage = async ({ searchParams }: AdminsPageProps) => {
+  const session = await getServerSession();
+  if (!session || session.adminRole !== "SUPER_ADMIN") notFound();
+
+  const { page, sort, order, q } = await parseAdminListParams(searchParams);
+  const { items, totalCount } = await listAdminsForAdmin({
+    page,
+    pageSize: PAGE_SIZE,
+    sort,
+    order,
+    search: q,
+  });
+  const admins = items.map(toAdminAccountDto);
+
+  return (
+    <section className="flex flex-col gap-6 p-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-800">Admins</h1>
+        <Link
+          href="/admins/new"
+          className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+        >
+          Adicionar admin
+        </Link>
+      </div>
+
+      <DataTable
+        columns={columns}
+        rows={admins}
+        rowKey={(admin) => admin.id}
+        page={page}
+        pageSize={PAGE_SIZE}
+        totalCount={totalCount}
+        basePath="/admins"
+        sort={sort ? { key: sort, order } : undefined}
+        searchValue={q}
+        searchPlaceholder="Pesquisar por nome ou email..."
+        renderActions={(admin) => (
+          <div className="flex items-center gap-3">
+            <Link
+              href={`/admins/${admin.id}/edit`}
+              aria-label={`Editar ${admin.name}`}
+              className="hover:text-primary"
+            >
+              ✏️
+            </Link>
+            <AdminToggleButton
+              checked={admin.active}
+              label={`Ativar/desativar ${admin.name}`}
+              patchUrl={`/admin/admins/${admin.id}`}
+              field="active"
+            />
+            <AdminDeleteButton
+              deleteUrl={`/admin/admins/${admin.id}`}
+              itemLabel={admin.name}
+              disabled={admin.id === session.id}
+              disabledReason="Não podes eliminar a tua própria conta"
+            />
+          </div>
+        )}
+      />
+    </section>
+  );
+};
+
+export default AdminsPage;

--- a/src/app/(admin)/admins/page.tsx
+++ b/src/app/(admin)/admins/page.tsx
@@ -85,8 +85,6 @@ const AdminsPage = async ({ searchParams }: AdminsPageProps) => {
             <AdminDeleteButton
               deleteUrl={`/admin/admins/${admin.id}`}
               itemLabel={admin.name}
-              disabled={admin.id === session.id}
-              disabledReason="Não podes eliminar a tua própria conta"
             />
           </div>
         )}

--- a/src/app/(admin)/giveaway/actions.ts
+++ b/src/app/(admin)/giveaway/actions.ts
@@ -18,7 +18,7 @@ interface GiveawayWinner {
  */
 export async function pickGiveawayWinner(): Promise<GiveawayWinner | null> {
   const session = await getServerSession();
-  if (!session || !session.isAdmin) {
+  if (!session || !session.adminRole) {
     throw new Error("Unauthorized");
   }
 

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -13,7 +13,7 @@ export default async function AdminLayout({
   children: React.ReactNode;
 }) {
   const session = await getServerSession();
-  if (!session || !session.isAdmin) {
+  if (!session || !session.adminRole) {
     notFound();
   }
 
@@ -21,7 +21,7 @@ export default async function AdminLayout({
     <SessionAuthLayout>
       <Topbar />
       <div className="flex min-h-screen pt-16">
-        <AdminSidebar />
+        <AdminSidebar isSuperAdmin={session.adminRole === "SUPER_ADMIN"} />
         <main id="main-content" className="min-w-0 flex-1">
           {children}
         </main>

--- a/src/app/(admin)/overview/page.tsx
+++ b/src/app/(admin)/overview/page.tsx
@@ -1,0 +1,34 @@
+import AdminActivityFeed from "@/components/AdminActivityFeed";
+import AdminStatTile from "@/components/AdminStatTile";
+import AdminWeeklyActivityChart from "@/components/AdminWeeklyActivityChart";
+import { getAdminDashboardSummary } from "@/application/services/adminDashboardService";
+
+const OverviewPage = async () => {
+  const summary = await getAdminDashboardSummary();
+
+  const tiles = [
+    { label: "Estudantes", value: summary.studentCount },
+    { label: "Empresas", value: summary.companyCount },
+    { label: "Recrutadores", value: summary.employeeCount },
+    { label: "Ações completadas", value: summary.actionCompletionCount },
+    { label: "Estudantes guardados", value: summary.savedStudentCount },
+  ];
+
+  return (
+    <section className="flex flex-col gap-6 p-8">
+      <h1 className="text-2xl font-bold text-gray-800">Dashboard</h1>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        {tiles.map((tile) => (
+          <AdminStatTile key={tile.label} {...tile} />
+        ))}
+      </div>
+
+      <AdminWeeklyActivityChart data={summary.weeklyActivity} />
+
+      <AdminActivityFeed events={summary.recentActivity} />
+    </section>
+  );
+};
+
+export default OverviewPage;

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -45,7 +45,11 @@ const submitLogin = () => {
 };
 
 test("sends an EMPLOYEE to the dashboard", async () => {
-  sessionUserMock.mockReturnValue({ role: "EMPLOYEE", student: null });
+  sessionUserMock.mockReturnValue({
+    role: "EMPLOYEE",
+    adminRole: null,
+    student: null,
+  });
 
   render(<LoginPage />);
   submitLogin();
@@ -56,6 +60,7 @@ test("sends an EMPLOYEE to the dashboard", async () => {
 test("sends a STUDENT with a profile to their student page", async () => {
   sessionUserMock.mockReturnValue({
     role: "STUDENT",
+    adminRole: null,
     student: { code: "s1", name: "Jane" },
   });
 
@@ -66,7 +71,11 @@ test("sends a STUDENT with a profile to their student page", async () => {
 });
 
 test("sends a STUDENT with no profile yet back into signup instead of the homepage", async () => {
-  sessionUserMock.mockReturnValue({ role: "STUDENT", student: null });
+  sessionUserMock.mockReturnValue({
+    role: "STUDENT",
+    adminRole: null,
+    student: null,
+  });
 
   render(<LoginPage />);
   submitLogin();
@@ -74,8 +83,38 @@ test("sends a STUDENT with no profile yet back into signup instead of the homepa
   await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/signup"));
 });
 
-test("falls back to the homepage for any other session shape", async () => {
-  sessionUserMock.mockReturnValue({ role: "ADMIN", student: null });
+test("sends an admin to the backoffice instead of the homepage, even though role is null", async () => {
+  sessionUserMock.mockReturnValue({
+    role: null,
+    adminRole: "ADMIN",
+    student: null,
+  });
+
+  render(<LoginPage />);
+  submitLogin();
+
+  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/students"));
+});
+
+test("sends a super admin to the backoffice too", async () => {
+  sessionUserMock.mockReturnValue({
+    role: null,
+    adminRole: "SUPER_ADMIN",
+    student: null,
+  });
+
+  render(<LoginPage />);
+  submitLogin();
+
+  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/students"));
+});
+
+test("falls back to the homepage for a session with no role and no admin tier", async () => {
+  sessionUserMock.mockReturnValue({
+    role: null,
+    adminRole: null,
+    student: null,
+  });
 
   render(<LoginPage />);
   submitLogin();

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -93,7 +93,7 @@ test("sends an admin to the backoffice instead of the homepage, even though role
   render(<LoginPage />);
   submitLogin();
 
-  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/students"));
+  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/overview"));
 });
 
 test("sends a super admin to the backoffice too", async () => {
@@ -106,7 +106,7 @@ test("sends a super admin to the backoffice too", async () => {
   render(<LoginPage />);
   submitLogin();
 
-  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/students"));
+  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/overview"));
 });
 
 test("falls back to the homepage for a session with no role and no admin tier", async () => {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -48,11 +48,16 @@ const LoginPage: React.FC = () => {
     if (await logIn(email, password)) {
       await session.fetchSession();
 
-      // Redirect based on user role. A STUDENT can be logging in with no
-      // Student row yet - e.g. AuthNEI established the account but the
-      // signup wizard was abandoned before it finished - so send them back
-      // into the wizard to complete it instead of the homepage.
-      if (session.user?.role === "EMPLOYEE") {
+      // Redirect based on user role. Checked before role, since an admin
+      // account has role: null (it isn't a STUDENT/EMPLOYEE at all) and
+      // would otherwise fall through to the generic "/" case below. A
+      // STUDENT can be logging in with no Student row yet - e.g. AuthNEI
+      // established the account but the signup wizard was abandoned before
+      // it finished - so send them back into the wizard to complete it
+      // instead of the homepage.
+      if (session.user?.adminRole) {
+        router.push("/students");
+      } else if (session.user?.role === "EMPLOYEE") {
         router.push("/dashboard");
       } else if (session.user?.role === "STUDENT") {
         router.push(

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -56,7 +56,7 @@ const LoginPage: React.FC = () => {
       // it finished - so send them back into the wizard to complete it
       // instead of the homepage.
       if (session.user?.adminRole) {
-        router.push("/students");
+        router.push("/overview");
       } else if (session.user?.role === "EMPLOYEE") {
         router.push("/dashboard");
       } else if (session.user?.role === "STUDENT") {

--- a/src/app/(profiles)/student/[...data]/page.test.tsx
+++ b/src/app/(profiles)/student/[...data]/page.test.tsx
@@ -111,7 +111,7 @@ test("a student viewing their own profile is not blocked", async () => {
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u1",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "s1", code: "S123", name: "Ana" },
     employee: null,
   } as never);
@@ -132,7 +132,7 @@ test("a different student viewing someone else's profile is blocked", async () =
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u2",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "s2", code: "S999", name: "Bea" },
     employee: null,
   } as never);
@@ -149,7 +149,7 @@ test("an employee whose company saved the student is not blocked", async () => {
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u3",
     role: "EMPLOYEE",
-    isAdmin: false,
+    adminRole: null,
     student: null,
     employee: { id: "e1", name: "Rui", companyId: "c1", company: { id: "c1" } },
   } as never);
@@ -169,7 +169,7 @@ test("an employee whose company hasn't saved the student is blocked", async () =
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u3",
     role: "EMPLOYEE",
-    isAdmin: false,
+    adminRole: null,
     student: null,
     employee: { id: "e1", name: "Rui", companyId: "c1", company: { id: "c1" } },
   } as never);

--- a/src/app/(profiles)/student/[...data]/page.tsx
+++ b/src/app/(profiles)/student/[...data]/page.tsx
@@ -83,7 +83,7 @@ const StudentPage = async (props: ProfileProps) => {
         : getStudentStats(student.code, {
             studentCode: session.student?.code,
             companyId: session.employee?.company?.id,
-            isAdmin: session.isAdmin,
+            isAdmin: session.adminRole !== null,
             // already computed above - avoids re-deriving the same isSaved
             // lookup a second time inside the ownership check
             isSaved: isSavedStudent,

--- a/src/app/api/actions/[id]/route.test.ts
+++ b/src/app/api/actions/[id]/route.test.ts
@@ -93,7 +93,7 @@ test("POST rejects a malformed/tampered scanned token with 400, without completi
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u1",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "s1", code: "S123", name: "Ana" },
     employee: null,
   } as never);
@@ -116,7 +116,7 @@ test("POST completes the action for a validly-scanned, unexpired token", async (
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u1",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "s1", code: "S123", name: "Ana" },
     employee: null,
   } as never);
@@ -146,7 +146,7 @@ test("POST rejects a scanned token once it's past its 30s expiry (the #212 regre
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u1",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "s1", code: "S123", name: "Ana" },
     employee: null,
   } as never);
@@ -182,7 +182,7 @@ test("PATCH rejects a non-admin session with 403", async () => {
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u1",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "s1", code: "S123", name: "Ana" },
     employee: null,
   } as never);
@@ -202,7 +202,7 @@ test("PATCH toggles the action live status for an admin", async () => {
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u1",
     role: "EMPLOYEE",
-    isAdmin: true,
+    adminRole: "ADMIN",
     student: null,
     employee: null,
   } as never);

--- a/src/app/api/admin/admins/[id]/route.ts
+++ b/src/app/api/admin/admins/[id]/route.ts
@@ -18,16 +18,16 @@ export const PATCH = defineHandler<
 >({
   auth: "superadmin",
   schema: updateAdminAccountSchema,
-  handler: async ({ session, params, body }) => {
-    const admin = await updateAdminAccount(params.id, session!.id, body);
+  handler: async ({ params, body }) => {
+    const admin = await updateAdminAccount(params.id, body);
     return NextResponse.json(toAdminAccountDto(admin));
   },
 });
 
 export const DELETE = defineHandler<AdminAccountParams>({
   auth: "superadmin",
-  handler: async ({ session, params }) => {
-    await deleteAdminAccount(params.id, session!.id);
+  handler: async ({ params }) => {
+    await deleteAdminAccount(params.id);
     return new NextResponse(null, { status: 204 });
   },
 });

--- a/src/app/api/admin/admins/[id]/route.ts
+++ b/src/app/api/admin/admins/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+import { defineHandler } from "@/lib/http/server";
+import { toAdminAccountDto } from "@/application/dto/adminAccountDto";
+import {
+  deleteAdminAccount,
+  updateAdminAccount,
+} from "@/application/services/adminAccountService";
+import { updateAdminAccountSchema } from "@/schemas/adminAccountSchema";
+
+interface AdminAccountParams {
+  id: string;
+}
+
+export const PATCH = defineHandler<
+  AdminAccountParams,
+  typeof updateAdminAccountSchema
+>({
+  auth: "superadmin",
+  schema: updateAdminAccountSchema,
+  handler: async ({ session, params, body }) => {
+    const admin = await updateAdminAccount(params.id, session!.id, body);
+    return NextResponse.json(toAdminAccountDto(admin));
+  },
+});
+
+export const DELETE = defineHandler<AdminAccountParams>({
+  auth: "superadmin",
+  handler: async ({ session, params }) => {
+    await deleteAdminAccount(params.id, session!.id);
+    return new NextResponse(null, { status: 204 });
+  },
+});

--- a/src/app/api/admin/admins/route.ts
+++ b/src/app/api/admin/admins/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+
+import { defineHandler } from "@/lib/http/server";
+import { toAdminAccountDto } from "@/application/dto/adminAccountDto";
+import {
+  createAdminAccount,
+  listAdminsForAdmin,
+} from "@/application/services/adminAccountService";
+import { createAdminAccountSchema } from "@/schemas/adminAccountSchema";
+
+export const GET = defineHandler({
+  auth: "superadmin",
+  handler: async ({ req }) => {
+    const params = req.nextUrl.searchParams;
+    const { items, totalCount } = await listAdminsForAdmin({
+      page: Math.max(1, Number(params.get("page")) || 1),
+      pageSize: 20,
+      sort: params.get("sort") ?? undefined,
+      order: params.get("order") === "desc" ? "desc" : "asc",
+      search: params.get("q") ?? undefined,
+    });
+    return NextResponse.json({
+      items: items.map(toAdminAccountDto),
+      totalCount,
+    });
+  },
+});
+
+export const POST = defineHandler({
+  auth: "superadmin",
+  schema: createAdminAccountSchema,
+  handler: async ({ body }) => {
+    const admin = await createAdminAccount(body);
+    return NextResponse.json(toAdminAccountDto(admin), { status: 201 });
+  },
+});

--- a/src/app/api/admin/faqs/[id]/route.test.ts
+++ b/src/app/api/admin/faqs/[id]/route.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 const adminSession = {
   id: "u1",
   role: "EMPLOYEE",
-  isAdmin: true,
+  adminRole: "ADMIN",
   student: null,
   employee: null,
 };
@@ -37,7 +37,7 @@ const adminSession = {
 const nonAdminSession = {
   id: "u2",
   role: "STUDENT",
-  isAdmin: false,
+  adminRole: null,
   student: { id: "s1", code: "S123", name: "Ana" },
   employee: null,
 };

--- a/src/app/api/admin/faqs/order/route.test.ts
+++ b/src/app/api/admin/faqs/order/route.test.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
 const adminSession = {
   id: "u1",
   role: "EMPLOYEE",
-  isAdmin: true,
+  adminRole: "ADMIN",
   student: null,
   employee: null,
 };
@@ -36,7 +36,7 @@ const adminSession = {
 const nonAdminSession = {
   id: "u2",
   role: "STUDENT",
-  isAdmin: false,
+  adminRole: null,
   student: { id: "s1", code: "S123", name: "Ana" },
   employee: null,
 };

--- a/src/app/api/admin/faqs/route.test.ts
+++ b/src/app/api/admin/faqs/route.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 const adminSession = {
   id: "u1",
   role: "EMPLOYEE",
-  isAdmin: true,
+  adminRole: "ADMIN",
   student: null,
   employee: null,
 };
@@ -37,7 +37,7 @@ const adminSession = {
 const nonAdminSession = {
   id: "u2",
   role: "STUDENT",
-  isAdmin: false,
+  adminRole: null,
   student: { id: "s1", code: "S123", name: "Ana" },
   employee: null,
 };

--- a/src/app/api/admin/schedule/[id]/route.test.ts
+++ b/src/app/api/admin/schedule/[id]/route.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 const adminSession = {
   id: "u1",
   role: "EMPLOYEE",
-  isAdmin: true,
+  adminRole: "ADMIN",
   student: null,
   employee: null,
 };
@@ -37,7 +37,7 @@ const adminSession = {
 const nonAdminSession = {
   id: "u2",
   role: "STUDENT",
-  isAdmin: false,
+  adminRole: null,
   student: { id: "s1", code: "S123", name: "Ana" },
   employee: null,
 };

--- a/src/app/api/admin/schedule/order/route.test.ts
+++ b/src/app/api/admin/schedule/order/route.test.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
 const adminSession = {
   id: "u1",
   role: "EMPLOYEE",
-  isAdmin: true,
+  adminRole: "ADMIN",
   student: null,
   employee: null,
 };
@@ -36,7 +36,7 @@ const adminSession = {
 const nonAdminSession = {
   id: "u2",
   role: "STUDENT",
-  isAdmin: false,
+  adminRole: null,
   student: { id: "s1", code: "S123", name: "Ana" },
   employee: null,
 };

--- a/src/app/api/admin/schedule/route.test.ts
+++ b/src/app/api/admin/schedule/route.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 const adminSession = {
   id: "u1",
   role: "EMPLOYEE",
-  isAdmin: true,
+  adminRole: "ADMIN",
   student: null,
   employee: null,
 };
@@ -37,7 +37,7 @@ const adminSession = {
 const nonAdminSession = {
   id: "u2",
   role: "STUDENT",
-  isAdmin: false,
+  adminRole: null,
   student: { id: "s1", code: "S123", name: "Ana" },
   employee: null,
 };

--- a/src/app/api/admin/storage/avatar/route.ts
+++ b/src/app/api/admin/storage/avatar/route.ts
@@ -15,7 +15,7 @@ import { createAdminClient } from "@/utils/supabase/admin";
 // behalf of a Company/Sponsor needs "any record", not "their own record".
 export async function POST(req: NextRequest) {
   const session = await getServerSession();
-  if (!session || !session.isAdmin) {
+  if (!session || !session.adminRole) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/qrcode/route.test.ts
+++ b/src/app/api/qrcode/route.test.ts
@@ -42,7 +42,7 @@ test("rejects a non-student session (e.g. an employee) with 403", async () => {
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u1",
     role: "EMPLOYEE",
-    isAdmin: false,
+    adminRole: null,
     student: null,
     employee: { id: "e1", name: "Rui", companyId: "c1", company: {} },
   } as never);
@@ -60,7 +60,7 @@ test("returns a token embedding the student's own code, verifiable with a ~30 mi
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u1",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "s1", code: "S123", name: "Ana" },
     employee: null,
   } as never);

--- a/src/app/api/saved/route.ts
+++ b/src/app/api/saved/route.ts
@@ -40,7 +40,7 @@ export const POST = defineHandler({
       employeeId: session!.employee!.id,
       companyId: session!.employee!.company!.id,
       comment: body.comment,
-      allowDuplicate: session!.isAdmin,
+      allowDuplicate: session!.adminRole !== null,
       completeBoothAction: true,
     });
     return NextResponse.json({ message: "Student scanned" }, { status: 201 });

--- a/src/app/api/students/[code]/cv/route.ts
+++ b/src/app/api/students/[code]/cv/route.ts
@@ -17,7 +17,7 @@ export const GET = defineHandler<StudentParams>({
     const url = await getStudentCv(params.code, {
       studentCode: session!.student?.code,
       companyId: session!.employee?.company?.id,
-      isAdmin: session!.isAdmin,
+      isAdmin: session!.adminRole !== null,
     });
     return NextResponse.json({ url });
   },

--- a/src/app/api/students/[code]/route.ts
+++ b/src/app/api/students/[code]/route.ts
@@ -21,7 +21,7 @@ export const GET = defineHandler<StudentParams>({
     const student = await getStudentProfile(params.code, {
       studentCode: session!.student?.code,
       companyId: session!.employee?.company?.id,
-      isAdmin: session!.isAdmin,
+      isAdmin: session!.adminRole !== null,
     });
     return NextResponse.json(toStudentDto(student));
   },

--- a/src/app/api/students/[code]/stats/route.test.ts
+++ b/src/app/api/students/[code]/stats/route.test.ts
@@ -37,7 +37,7 @@ test("passes the caller's ownership info through to getStudentStats and returns 
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u1",
     role: "EMPLOYEE",
-    isAdmin: false,
+    adminRole: null,
     student: null,
     employee: { id: "e1", name: "Rui", companyId: "c1", company: { id: "c1" } },
   } as never);
@@ -70,7 +70,7 @@ test("propagates getStudentStats' 404 for an unauthorized caller", async () => {
   vi.mocked(getServerSession).mockResolvedValue({
     id: "u2",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "s2", code: "S999", name: "Bea" },
     employee: null,
   } as never);

--- a/src/app/api/students/[code]/stats/route.ts
+++ b/src/app/api/students/[code]/stats/route.ts
@@ -14,7 +14,7 @@ export const GET = defineHandler<StudentParams>({
       await getStudentStats(params.code, {
         studentCode: session!.student?.code,
         companyId: session!.employee?.company?.id,
-        isAdmin: session!.isAdmin,
+        isAdmin: session!.adminRole !== null,
       })
     );
   },

--- a/src/application/boundaries.test.ts
+++ b/src/application/boundaries.test.ts
@@ -105,6 +105,7 @@ test("public DTO mappers omit private database fields", () => {
   });
   assert.deepEqual(toSessionDto(session), {
     role: "STUDENT",
+    adminRole: "ADMIN",
     student: { code: "ABC123", name: "Student" },
   });
   assert.deepEqual(toInterestDto({ id: "interest-id", name: "TypeScript" }), {

--- a/src/application/boundaries.test.ts
+++ b/src/application/boundaries.test.ts
@@ -92,7 +92,7 @@ test("public DTO mappers omit private database fields", () => {
     id: "user-id",
     email: "private@example.com",
     role: "STUDENT" as const,
-    isAdmin: true,
+    adminRole: "ADMIN" as const,
     updatedAt: new Date(),
     student: { id: "user-id", code: "ABC123", name: "Student" },
   };

--- a/src/application/dto/adminAccountDto.ts
+++ b/src/application/dto/adminAccountDto.ts
@@ -1,0 +1,23 @@
+export interface AdminAccountDto {
+  id: string;
+  email: string;
+  name: string;
+  adminRole: "ADMIN" | "SUPER_ADMIN";
+  active: boolean;
+}
+
+export const toAdminAccountDto = (admin: {
+  id: string;
+  email: string;
+  name: string | null;
+  adminRole: "ADMIN" | "SUPER_ADMIN" | null;
+  active: boolean;
+}): AdminAccountDto => ({
+  id: admin.id,
+  email: admin.email,
+  name: admin.name ?? "",
+  // adminWhere() already filters to adminRole IS NOT NULL - this cast just
+  // reflects that narrowing to Prisma's nullable column type.
+  adminRole: admin.adminRole as "ADMIN" | "SUPER_ADMIN",
+  active: admin.active,
+});

--- a/src/application/dto/sessionDto.ts
+++ b/src/application/dto/sessionDto.ts
@@ -1,5 +1,5 @@
 export interface SessionDto {
-  role: "STUDENT" | "EMPLOYEE";
+  role: "STUDENT" | "EMPLOYEE" | null;
   student: {
     code: string;
     name: string;

--- a/src/application/dto/sessionDto.ts
+++ b/src/application/dto/sessionDto.ts
@@ -1,5 +1,6 @@
 export interface SessionDto {
   role: "STUDENT" | "EMPLOYEE" | null;
+  adminRole: "ADMIN" | "SUPER_ADMIN" | null;
   student: {
     code: string;
     name: string;
@@ -8,6 +9,7 @@ export interface SessionDto {
 
 export const toSessionDto = (session: SessionDto): SessionDto => ({
   role: session.role,
+  adminRole: session.adminRole,
   student: session.student
     ? { code: session.student.code, name: session.student.name }
     : null,

--- a/src/application/repositories/actionRepository.ts
+++ b/src/application/repositories/actionRepository.ts
@@ -97,3 +97,26 @@ export const upsertActionCompletion = (
 
 export const toggleAction = (id: string, isLive: boolean) =>
   prisma.action.update({ where: { id }, data: { isLive } });
+
+export const countActionCompletions = () => prisma.actionCompletion.count();
+
+export const findRecentActionCompletions = (limit: number) =>
+  prisma.actionCompletion.findMany({
+    orderBy: { completedAt: "desc" },
+    take: limit,
+    select: {
+      completedAt: true,
+      student: { select: { name: true } },
+      action: { select: { name: true } },
+    },
+  });
+
+// Bucketing by day happens in the service layer - this just returns the raw
+// timestamps for the window, which is small enough (a single-event fair, not
+// a high-volume product) that fetching rows and grouping in JS is simpler
+// and more portable than a DB-side date_trunc.
+export const findActionCompletionTimestampsSince = (since: Date) =>
+  prisma.actionCompletion.findMany({
+    where: { completedAt: { gte: since } },
+    select: { completedAt: true },
+  });

--- a/src/application/repositories/adminRepository.ts
+++ b/src/application/repositories/adminRepository.ts
@@ -1,0 +1,79 @@
+import "server-only";
+
+import type { AdminRole, Prisma } from "@prisma/client";
+
+import { Email } from "@/types/Email";
+
+import prisma, { DbClient } from "./database";
+
+const ADMIN_SORTABLE_FIELDS = ["name", "email"] as const;
+export type AdminAccountSortField = (typeof ADMIN_SORTABLE_FIELDS)[number];
+
+export interface AdminAccountQuery {
+  page: number;
+  pageSize: number;
+  sort?: string;
+  order: "asc" | "desc";
+  search?: string;
+}
+
+const adminSelect = {
+  id: true,
+  email: true,
+  name: true,
+  adminRole: true,
+  active: true,
+} satisfies Prisma.UserSelect;
+
+function adminWhere(search?: string): Prisma.UserWhereInput {
+  const base: Prisma.UserWhereInput = { adminRole: { not: null } };
+  if (!search) return base;
+  return {
+    ...base,
+    OR: [
+      { name: { contains: search, mode: "insensitive" } },
+      { email: { contains: search, mode: "insensitive" } },
+    ],
+  };
+}
+
+export const countAdminsForAdmin = (search?: string) =>
+  prisma.user.count({ where: adminWhere(search) });
+
+export const findAdminsForAdmin = ({
+  page,
+  pageSize,
+  sort,
+  order,
+  search,
+}: AdminAccountQuery) =>
+  prisma.user.findMany({
+    where: adminWhere(search),
+    orderBy: ADMIN_SORTABLE_FIELDS.includes(sort as AdminAccountSortField)
+      ? { [sort as AdminAccountSortField]: order }
+      : { name: "asc" },
+    skip: (page - 1) * pageSize,
+    take: pageSize,
+    select: adminSelect,
+  });
+
+export const findAdminAccountById = (id: string) =>
+  prisma.user.findFirst({
+    where: { id, adminRole: { not: null } },
+    select: adminSelect,
+  });
+
+export const createAdminUser = (
+  data: { id: string; email: Email; name: string; adminRole: AdminRole },
+  db: DbClient = prisma
+) =>
+  db.user.create({
+    data: { ...data, role: null },
+    select: adminSelect,
+  });
+
+export const updateAdminUserFields = (
+  id: string,
+  data: { name?: string; adminRole?: AdminRole },
+  db: DbClient = prisma
+) => db.user.update({ where: { id }, data, select: adminSelect });

--- a/src/application/repositories/adminRepository.ts
+++ b/src/application/repositories/adminRepository.ts
@@ -40,6 +40,9 @@ function adminWhere(search?: string): Prisma.UserWhereInput {
 export const countAdminsForAdmin = (search?: string) =>
   prisma.user.count({ where: adminWhere(search) });
 
+export const countActiveSuperAdmins = () =>
+  prisma.user.count({ where: { adminRole: "SUPER_ADMIN", active: true } });
+
 export const findAdminsForAdmin = ({
   page,
   pageSize,

--- a/src/application/repositories/savedStudentRepository.ts
+++ b/src/application/repositories/savedStudentRepository.ts
@@ -60,6 +60,27 @@ export const countCompanySaves = (companyId: string) =>
 export const countSavedStudentsByCompany = () =>
   prisma.savedStudent.groupBy({ by: ["companyId"], _count: { _all: true } });
 
+export const countAllSavedStudents = () => prisma.savedStudent.count();
+
+export const findRecentSavedStudents = (limit: number) =>
+  prisma.savedStudent.findMany({
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: {
+      createdAt: true,
+      student: { select: { name: true } },
+      company: { select: { name: true } },
+    },
+  });
+
+// See findActionCompletionTimestampsSince's comment - same small-scale
+// rationale for bucketing in the service layer instead of DB-side.
+export const findSavedStudentTimestampsSince = (since: Date) =>
+  prisma.savedStudent.findMany({
+    where: { createdAt: { gte: since } },
+    select: { createdAt: true },
+  });
+
 export const findCompanyHistory = (companyId: string) =>
   prisma.savedStudent.findMany({
     where: { companyId },

--- a/src/application/repositories/studentRepository.ts
+++ b/src/application/repositories/studentRepository.ts
@@ -82,6 +82,23 @@ export const updateStudentCv = (
 export const countStudents = () =>
   prisma.student.count({ where: { user: { AND: [{ role: "STUDENT" }] } } });
 
+export const findRecentStudents = (limit: number) =>
+  prisma.student.findMany({
+    where: { user: { role: "STUDENT" } },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: { name: true, createdAt: true },
+  });
+
+// See actionRepository's findActionCompletionTimestampsSince comment - same
+// small-scale rationale for bucketing in the service layer instead of
+// DB-side.
+export const findStudentSignupTimestampsSince = (since: Date) =>
+  prisma.student.findMany({
+    where: { user: { role: "STUDENT" }, createdAt: { gte: since } },
+    select: { createdAt: true },
+  });
+
 export const findAllStudents = () =>
   prisma.student.findMany({
     where: { user: { AND: [{ role: "STUDENT" }] } },

--- a/src/application/repositories/studentRepository.ts
+++ b/src/application/repositories/studentRepository.ts
@@ -100,7 +100,7 @@ export const findAllStudents = () =>
 
 export const findStudentsForGiveaway = () =>
   prisma.student.findMany({
-    where: { user: { AND: [{ role: "STUDENT" }, { isAdmin: false }] } },
+    where: { user: { AND: [{ role: "STUDENT" }, { adminRole: null }] } },
     include: {
       user: true,
       actionCompletions: { select: { action: { select: { points: true } } } },

--- a/src/application/repositories/userRepository.ts
+++ b/src/application/repositories/userRepository.ts
@@ -9,7 +9,7 @@ import prisma, { DbClient } from "./database";
 const sessionSelect = {
   id: true,
   role: true,
-  isAdmin: true,
+  adminRole: true,
   active: true,
   student: { select: { id: true, code: true, name: true } },
   employee: {

--- a/src/application/services/adminAccountService.test.ts
+++ b/src/application/services/adminAccountService.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, expect, test, vi } from "vitest";
 import { Email } from "@/types/Email";
 
 import {
+  countActiveSuperAdmins,
   createAdminUser,
   findAdminAccountById,
   updateAdminUserFields,
@@ -11,6 +12,7 @@ import { deleteUser, updateUserActive } from "../repositories/userRepository";
 import {
   createAdminAccount,
   deleteAdminAccount,
+  getAdminAccountById,
   updateAdminAccount,
 } from "./adminAccountService";
 import {
@@ -24,6 +26,7 @@ vi.mock("@/utils/supabase/admin", () => ({
   createAdminClient: vi.fn(),
 }));
 vi.mock("../repositories/adminRepository", () => ({
+  countActiveSuperAdmins: vi.fn(),
   createAdminUser: vi.fn(),
   findAdminAccountById: vi.fn(),
   findAdminsForAdmin: vi.fn(),
@@ -40,9 +43,14 @@ vi.mock("./authApplicationService", () => ({
   setAuthUserBanned: vi.fn(),
 }));
 
+const superAdminTarget = { adminRole: "SUPER_ADMIN", active: true } as never;
+const regularAdminTarget = { adminRole: "ADMIN", active: true } as never;
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(updateAdminUserFields).mockResolvedValue({ id: "a1" } as never);
+  vi.mocked(findAdminAccountById).mockResolvedValue(regularAdminTarget);
+  vi.mocked(countActiveSuperAdmins).mockResolvedValue(2);
 });
 
 test("creating an admin rolls back the Supabase auth user if the DB write fails", async () => {
@@ -53,7 +61,7 @@ test("creating an admin rolls back the Supabase auth user if the DB write fails"
 
   await expect(
     createAdminAccount({
-      email: "admin@isep.ipp.pt",
+      email: Email.create("admin@isep.ipp.pt"),
       password: "password123",
       name: "New Admin",
       adminRole: "ADMIN",
@@ -70,7 +78,7 @@ test("creating an admin passes the display name through to Supabase and the DB r
   vi.mocked(createAdminUser).mockResolvedValue({ id: "new-admin-id" } as never);
 
   await createAdminAccount({
-    email: "admin@isep.ipp.pt",
+    email: Email.create("admin@isep.ipp.pt"),
     password: "password123",
     name: "New Admin",
     adminRole: "SUPER_ADMIN",
@@ -89,47 +97,92 @@ test("creating an admin passes the display name through to Supabase and the DB r
   });
 });
 
-test("a super admin can't deactivate their own account", async () => {
-  await expect(
-    updateAdminAccount("a1", "a1", { active: false })
-  ).rejects.toThrow("own admin account");
+test("can't deactivate the last active super admin", async () => {
+  vi.mocked(findAdminAccountById).mockResolvedValue(superAdminTarget);
+  vi.mocked(countActiveSuperAdmins).mockResolvedValue(1);
+
+  await expect(updateAdminAccount("a1", { active: false })).rejects.toThrow(
+    "last active Super Admin"
+  );
 
   expect(updateUserActive).not.toHaveBeenCalled();
   expect(setAuthUserBanned).not.toHaveBeenCalled();
 });
 
-test("a super admin can deactivate a different admin's account", async () => {
-  await updateAdminAccount("a2", "a1", { active: false });
+test("can deactivate a super admin when another active one remains", async () => {
+  vi.mocked(findAdminAccountById).mockResolvedValue(superAdminTarget);
+  vi.mocked(countActiveSuperAdmins).mockResolvedValue(2);
 
-  expect(updateUserActive).toHaveBeenCalledWith("a2", false);
-  expect(setAuthUserBanned).toHaveBeenCalledWith("a2", true);
+  await updateAdminAccount("a1", { active: false });
+
+  expect(updateUserActive).toHaveBeenCalledWith("a1", false);
+  expect(setAuthUserBanned).toHaveBeenCalledWith("a1", true);
 });
 
-test("a super admin can demote themselves (only deactivation/deletion is blocked)", async () => {
+test("can't demote the last active super admin", async () => {
+  vi.mocked(findAdminAccountById).mockResolvedValue(superAdminTarget);
+  vi.mocked(countActiveSuperAdmins).mockResolvedValue(1);
+
   await expect(
-    updateAdminAccount("a1", "a1", { adminRole: "ADMIN" })
-  ).resolves.toBeDefined();
+    updateAdminAccount("a1", { adminRole: "ADMIN" })
+  ).rejects.toThrow("last active Super Admin");
+
+  expect(updateAdminUserFields).not.toHaveBeenCalled();
+});
+
+test("can demote a super admin when another active one remains (including themselves)", async () => {
+  vi.mocked(findAdminAccountById).mockResolvedValue(superAdminTarget);
+  vi.mocked(countActiveSuperAdmins).mockResolvedValue(2);
+
+  await updateAdminAccount("a1", { adminRole: "ADMIN" });
 
   expect(updateAdminUserFields).toHaveBeenCalledWith("a1", {
     adminRole: "ADMIN",
   });
 });
 
-test("a super admin can't delete their own account", async () => {
-  await expect(deleteAdminAccount("a1", "a1")).rejects.toThrow(
-    "own admin account"
+test("deactivating/renaming a regular admin never checks the super admin count", async () => {
+  vi.mocked(findAdminAccountById).mockResolvedValue(regularAdminTarget);
+
+  await updateAdminAccount("a2", { active: false, name: "New Name" });
+
+  expect(countActiveSuperAdmins).not.toHaveBeenCalled();
+  expect(updateUserActive).toHaveBeenCalledWith("a2", false);
+});
+
+test("an already-inactive super admin doesn't block further action on their row", async () => {
+  vi.mocked(findAdminAccountById).mockResolvedValue({
+    adminRole: "SUPER_ADMIN",
+    active: false,
+  } as never);
+
+  await expect(deleteAdminAccount("a1")).resolves.toBeUndefined();
+
+  expect(countActiveSuperAdmins).not.toHaveBeenCalled();
+  expect(deleteUser).toHaveBeenCalledWith("a1");
+});
+
+test("can't delete the last active super admin", async () => {
+  vi.mocked(findAdminAccountById).mockResolvedValue(superAdminTarget);
+  vi.mocked(countActiveSuperAdmins).mockResolvedValue(1);
+
+  await expect(deleteAdminAccount("a1")).rejects.toThrow(
+    "last active Super Admin"
   );
   expect(deleteUser).not.toHaveBeenCalled();
 });
 
-test("a super admin can delete a different admin's account", async () => {
-  await deleteAdminAccount("a2", "a1");
+test("can delete a regular admin's account freely", async () => {
+  vi.mocked(findAdminAccountById).mockResolvedValue(regularAdminTarget);
+
+  await deleteAdminAccount("a2");
+
+  expect(countActiveSuperAdmins).not.toHaveBeenCalled();
   expect(deleteUser).toHaveBeenCalledWith("a2");
 });
 
 test("getAdminAccountById is a thin passthrough to the repository", async () => {
   vi.mocked(findAdminAccountById).mockResolvedValue({ id: "a1" } as never);
-  const { getAdminAccountById } = await import("./adminAccountService");
 
   await expect(getAdminAccountById("a1")).resolves.toEqual({ id: "a1" });
   expect(findAdminAccountById).toHaveBeenCalledWith("a1");

--- a/src/application/services/adminAccountService.test.ts
+++ b/src/application/services/adminAccountService.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { Email } from "@/types/Email";
+
+import {
+  createAdminUser,
+  findAdminAccountById,
+  updateAdminUserFields,
+} from "../repositories/adminRepository";
+import { deleteUser, updateUserActive } from "../repositories/userRepository";
+import {
+  createAdminAccount,
+  deleteAdminAccount,
+  updateAdminAccount,
+} from "./adminAccountService";
+import {
+  createSupabaseAuthUserAsAdmin,
+  rollbackAuthUser,
+  setAuthUserBanned,
+} from "./authApplicationService";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/supabase/admin", () => ({
+  createAdminClient: vi.fn(),
+}));
+vi.mock("../repositories/adminRepository", () => ({
+  createAdminUser: vi.fn(),
+  findAdminAccountById: vi.fn(),
+  findAdminsForAdmin: vi.fn(),
+  countAdminsForAdmin: vi.fn(),
+  updateAdminUserFields: vi.fn(),
+}));
+vi.mock("../repositories/userRepository", () => ({
+  updateUserActive: vi.fn(),
+  deleteUser: vi.fn(),
+}));
+vi.mock("./authApplicationService", () => ({
+  createSupabaseAuthUserAsAdmin: vi.fn(),
+  rollbackAuthUser: vi.fn(),
+  setAuthUserBanned: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(updateAdminUserFields).mockResolvedValue({ id: "a1" } as never);
+});
+
+test("creating an admin rolls back the Supabase auth user if the DB write fails", async () => {
+  vi.mocked(createSupabaseAuthUserAsAdmin).mockResolvedValue({
+    id: "new-admin-id",
+  } as never);
+  vi.mocked(createAdminUser).mockRejectedValue(new Error("db down"));
+
+  await expect(
+    createAdminAccount({
+      email: "admin@isep.ipp.pt",
+      password: "password123",
+      name: "New Admin",
+      adminRole: "ADMIN",
+    })
+  ).rejects.toThrow("db down");
+
+  expect(rollbackAuthUser).toHaveBeenCalledWith("new-admin-id");
+});
+
+test("creating an admin passes the display name through to Supabase and the DB row", async () => {
+  vi.mocked(createSupabaseAuthUserAsAdmin).mockResolvedValue({
+    id: "new-admin-id",
+  } as never);
+  vi.mocked(createAdminUser).mockResolvedValue({ id: "new-admin-id" } as never);
+
+  await createAdminAccount({
+    email: "admin@isep.ipp.pt",
+    password: "password123",
+    name: "New Admin",
+    adminRole: "SUPER_ADMIN",
+  });
+
+  expect(createSupabaseAuthUserAsAdmin).toHaveBeenCalledWith(
+    "admin@isep.ipp.pt",
+    "password123",
+    "New Admin"
+  );
+  expect(createAdminUser).toHaveBeenCalledWith({
+    id: "new-admin-id",
+    email: Email.create("admin@isep.ipp.pt"),
+    name: "New Admin",
+    adminRole: "SUPER_ADMIN",
+  });
+});
+
+test("a super admin can't deactivate their own account", async () => {
+  await expect(
+    updateAdminAccount("a1", "a1", { active: false })
+  ).rejects.toThrow("own admin account");
+
+  expect(updateUserActive).not.toHaveBeenCalled();
+  expect(setAuthUserBanned).not.toHaveBeenCalled();
+});
+
+test("a super admin can deactivate a different admin's account", async () => {
+  await updateAdminAccount("a2", "a1", { active: false });
+
+  expect(updateUserActive).toHaveBeenCalledWith("a2", false);
+  expect(setAuthUserBanned).toHaveBeenCalledWith("a2", true);
+});
+
+test("a super admin can demote themselves (only deactivation/deletion is blocked)", async () => {
+  await expect(
+    updateAdminAccount("a1", "a1", { adminRole: "ADMIN" })
+  ).resolves.toBeDefined();
+
+  expect(updateAdminUserFields).toHaveBeenCalledWith("a1", {
+    adminRole: "ADMIN",
+  });
+});
+
+test("a super admin can't delete their own account", async () => {
+  await expect(deleteAdminAccount("a1", "a1")).rejects.toThrow(
+    "own admin account"
+  );
+  expect(deleteUser).not.toHaveBeenCalled();
+});
+
+test("a super admin can delete a different admin's account", async () => {
+  await deleteAdminAccount("a2", "a1");
+  expect(deleteUser).toHaveBeenCalledWith("a2");
+});
+
+test("getAdminAccountById is a thin passthrough to the repository", async () => {
+  vi.mocked(findAdminAccountById).mockResolvedValue({ id: "a1" } as never);
+  const { getAdminAccountById } = await import("./adminAccountService");
+
+  await expect(getAdminAccountById("a1")).resolves.toEqual({ id: "a1" });
+  expect(findAdminAccountById).toHaveBeenCalledWith("a1");
+});

--- a/src/application/services/adminAccountService.ts
+++ b/src/application/services/adminAccountService.ts
@@ -1,0 +1,102 @@
+import "server-only";
+
+import type { AdminRole } from "@prisma/client";
+
+import { Email } from "@/types/Email";
+import { HttpError } from "@/types/HttpError";
+import { createAdminClient } from "@/utils/supabase/admin";
+
+import {
+  countAdminsForAdmin,
+  createAdminUser,
+  findAdminAccountById,
+  findAdminsForAdmin,
+  updateAdminUserFields,
+  type AdminAccountQuery,
+} from "../repositories/adminRepository";
+import { deleteUser, updateUserActive } from "../repositories/userRepository";
+import {
+  createSupabaseAuthUserAsAdmin,
+  rollbackAuthUser,
+  setAuthUserBanned,
+} from "./authApplicationService";
+
+export const getAdminAccountById = (id: string) => findAdminAccountById(id);
+
+export async function listAdminsForAdmin(query: AdminAccountQuery) {
+  const [items, totalCount] = await Promise.all([
+    findAdminsForAdmin(query),
+    countAdminsForAdmin(query.search),
+  ]);
+  return { items, totalCount };
+}
+
+export async function createAdminAccount(input: {
+  email: string;
+  password: string;
+  name: string;
+  adminRole: AdminRole;
+}) {
+  const authUser = await createSupabaseAuthUserAsAdmin(
+    input.email,
+    input.password,
+    input.name
+  );
+  try {
+    return await createAdminUser({
+      id: authUser.id,
+      email: Email.create(input.email),
+      name: input.name,
+      adminRole: input.adminRole,
+    });
+  } catch (error) {
+    await rollbackAuthUser(authUser.id);
+    throw error;
+  }
+}
+
+// Prevents a super admin from locking every admin out (including
+// themselves) by deactivating or deleting their own account through this
+// same panel - a demotion is still allowed, since that's recoverable by any
+// other super admin (or the DB directly), unlike losing all admin access.
+function assertNotActingOnSelf(id: string, actingAdminId: string) {
+  if (id === actingAdminId)
+    throw new HttpError(
+      "You can't deactivate or delete your own admin account",
+      400
+    );
+}
+
+export async function updateAdminAccount(
+  id: string,
+  actingAdminId: string,
+  input: {
+    name?: string;
+    adminRole?: AdminRole;
+    password?: string;
+    active?: boolean;
+  }
+) {
+  const { password, active, ...fields } = input;
+  if (active === false) assertNotActingOnSelf(id, actingAdminId);
+
+  const admin = await updateAdminUserFields(id, fields);
+
+  if (active !== undefined) {
+    await updateUserActive(id, active);
+    await setAuthUserBanned(id, !active);
+  }
+  if (password) {
+    const supabaseAdmin = createAdminClient();
+    const { error } = await supabaseAdmin.auth.admin.updateUserById(id, {
+      password,
+    });
+    if (error) throw new HttpError(error.message, 400);
+  }
+  return admin;
+}
+
+export async function deleteAdminAccount(id: string, actingAdminId: string) {
+  assertNotActingOnSelf(id, actingAdminId);
+  await deleteUser(id);
+}

--- a/src/application/services/adminAccountService.ts
+++ b/src/application/services/adminAccountService.ts
@@ -7,6 +7,7 @@ import { HttpError } from "@/types/HttpError";
 import { createAdminClient } from "@/utils/supabase/admin";
 
 import {
+  countActiveSuperAdmins,
   countAdminsForAdmin,
   createAdminUser,
   findAdminAccountById,
@@ -32,7 +33,7 @@ export async function listAdminsForAdmin(query: AdminAccountQuery) {
 }
 
 export async function createAdminAccount(input: {
-  email: string;
+  email: Email;
   password: string;
   name: string;
   adminRole: AdminRole;
@@ -45,7 +46,7 @@ export async function createAdminAccount(input: {
   try {
     return await createAdminUser({
       id: authUser.id,
-      email: Email.create(input.email),
+      email: input.email,
       name: input.name,
       adminRole: input.adminRole,
     });
@@ -55,21 +56,28 @@ export async function createAdminAccount(input: {
   }
 }
 
-// Prevents a super admin from locking every admin out (including
-// themselves) by deactivating or deleting their own account through this
-// same panel - a demotion is still allowed, since that's recoverable by any
-// other super admin (or the DB directly), unlike losing all admin access.
-function assertNotActingOnSelf(id: string, actingAdminId: string) {
-  if (id === actingAdminId)
+// Guards demote/deactivate/delete against leaving zero *active* Super
+// Admins, however that would happen - not just self-action. The migration
+// that introduced admin tiers promotes nobody to SUPER_ADMIN automatically
+// and seedAdmin() only ever creates one, so a lone super admin demoting
+// themselves (no guard existed for this case at all) or deactivating/
+// deleting themselves would make /admins permanently unreachable (gated by
+// both the page-level check and the "superadmin" auth policy) with no UI
+// path back - only a direct DB write could recover it. An inactive super
+// admin doesn't count as available either, since they can't log in to help.
+async function assertNotLastActiveSuperAdmin(
+  target: { adminRole: AdminRole | null; active: boolean } | null
+) {
+  if (!target || target.adminRole !== "SUPER_ADMIN" || !target.active) return;
+  if ((await countActiveSuperAdmins()) <= 1)
     throw new HttpError(
-      "You can't deactivate or delete your own admin account",
+      "Can't remove the last active Super Admin - promote another admin first",
       400
     );
 }
 
 export async function updateAdminAccount(
   id: string,
-  actingAdminId: string,
   input: {
     name?: string;
     adminRole?: AdminRole;
@@ -78,7 +86,8 @@ export async function updateAdminAccount(
   }
 ) {
   const { password, active, ...fields } = input;
-  if (active === false) assertNotActingOnSelf(id, actingAdminId);
+  if (fields.adminRole === "ADMIN" || active === false)
+    await assertNotLastActiveSuperAdmin(await findAdminAccountById(id));
 
   const admin = await updateAdminUserFields(id, fields);
 
@@ -96,7 +105,7 @@ export async function updateAdminAccount(
   return admin;
 }
 
-export async function deleteAdminAccount(id: string, actingAdminId: string) {
-  assertNotActingOnSelf(id, actingAdminId);
+export async function deleteAdminAccount(id: string) {
+  await assertNotLastActiveSuperAdmin(await findAdminAccountById(id));
   await deleteUser(id);
 }

--- a/src/application/services/adminDashboardService.test.ts
+++ b/src/application/services/adminDashboardService.test.ts
@@ -103,6 +103,35 @@ test("merges the three activity sources into one feed, newest first", async () =
   });
 });
 
+test("fetches at least 15 events per source, so a single busy source can't hide a true top-15 event", async () => {
+  await getAdminDashboardSummary();
+
+  expect(findRecentStudents).toHaveBeenCalledWith(15);
+  expect(findRecentActionCompletions).toHaveBeenCalledWith(15);
+  expect(findRecentSavedStudents).toHaveBeenCalledWith(15);
+});
+
+test("doesn't drop the true most-recent events when one source is far busier than the others", async () => {
+  // 15 scans, all newer than every signup/save below - the real top 15.
+  const scans = Array.from({ length: 15 }, (_, i) => ({
+    completedAt: new Date(Date.UTC(2026, 6, 28, 12, i)),
+    student: { name: `Scanner ${i}` },
+    action: { name: "Visit Booth" },
+  }));
+  // Older events that must NOT displace any of the scans above.
+  const olderSignups = Array.from({ length: 5 }, (_, i) => ({
+    name: `Student ${i}`,
+    createdAt: new Date(Date.UTC(2026, 6, 27, 12, i)),
+  }));
+  vi.mocked(findRecentActionCompletions).mockResolvedValue(scans as never);
+  vi.mocked(findRecentStudents).mockResolvedValue(olderSignups as never);
+
+  const { recentActivity } = await getAdminDashboardSummary();
+
+  expect(recentActivity).toHaveLength(15);
+  expect(recentActivity.every((event) => event.type === "scan")).toBe(true);
+});
+
 test("caps the merged feed at 15 events even when more are available", async () => {
   const many = Array.from({ length: 10 }, (_, i) => ({
     name: `Student ${i}`,

--- a/src/application/services/adminDashboardService.test.ts
+++ b/src/application/services/adminDashboardService.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+import {
+  countActionCompletions,
+  findActionCompletionTimestampsSince,
+  findRecentActionCompletions,
+} from "../repositories/actionRepository";
+import { countCompaniesForAdmin } from "../repositories/companyRepository";
+import { countEmployeesForAdmin } from "../repositories/employeeRepository";
+import {
+  countAllSavedStudents,
+  findRecentSavedStudents,
+  findSavedStudentTimestampsSince,
+} from "../repositories/savedStudentRepository";
+import {
+  countStudents,
+  findRecentStudents,
+  findStudentSignupTimestampsSince,
+} from "../repositories/studentRepository";
+import { getAdminDashboardSummary } from "./adminDashboardService";
+
+vi.mock("server-only", () => ({}));
+vi.mock("../repositories/actionRepository", () => ({
+  countActionCompletions: vi.fn(),
+  findActionCompletionTimestampsSince: vi.fn(),
+  findRecentActionCompletions: vi.fn(),
+}));
+vi.mock("../repositories/companyRepository", () => ({
+  countCompaniesForAdmin: vi.fn(),
+}));
+vi.mock("../repositories/employeeRepository", () => ({
+  countEmployeesForAdmin: vi.fn(),
+}));
+vi.mock("../repositories/savedStudentRepository", () => ({
+  countAllSavedStudents: vi.fn(),
+  findRecentSavedStudents: vi.fn(),
+  findSavedStudentTimestampsSince: vi.fn(),
+}));
+vi.mock("../repositories/studentRepository", () => ({
+  countStudents: vi.fn(),
+  findRecentStudents: vi.fn(),
+  findStudentSignupTimestampsSince: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(countStudents).mockResolvedValue(10);
+  vi.mocked(countCompaniesForAdmin).mockResolvedValue(3);
+  vi.mocked(countEmployeesForAdmin).mockResolvedValue(5);
+  vi.mocked(countActionCompletions).mockResolvedValue(20);
+  vi.mocked(countAllSavedStudents).mockResolvedValue(7);
+  vi.mocked(findRecentStudents).mockResolvedValue([]);
+  vi.mocked(findRecentActionCompletions).mockResolvedValue([]);
+  vi.mocked(findRecentSavedStudents).mockResolvedValue([]);
+  vi.mocked(findStudentSignupTimestampsSince).mockResolvedValue([]);
+  vi.mocked(findActionCompletionTimestampsSince).mockResolvedValue([]);
+  vi.mocked(findSavedStudentTimestampsSince).mockResolvedValue([]);
+});
+
+test("passes the raw counts straight through", async () => {
+  const summary = await getAdminDashboardSummary();
+
+  expect(summary.studentCount).toBe(10);
+  expect(summary.companyCount).toBe(3);
+  expect(summary.employeeCount).toBe(5);
+  expect(summary.actionCompletionCount).toBe(20);
+  expect(summary.savedStudentCount).toBe(7);
+});
+
+test("merges the three activity sources into one feed, newest first", async () => {
+  vi.mocked(findRecentStudents).mockResolvedValue([
+    { name: "Ana", createdAt: new Date("2026-07-27T10:00:00Z") } as never,
+  ]);
+  vi.mocked(findRecentActionCompletions).mockResolvedValue([
+    {
+      completedAt: new Date("2026-07-28T09:00:00Z"),
+      student: { name: "Bea" },
+      action: { name: "Visit Booth" },
+    } as never,
+  ]);
+  vi.mocked(findRecentSavedStudents).mockResolvedValue([
+    {
+      createdAt: new Date("2026-07-27T15:00:00Z"),
+      student: { name: "Ana" },
+      company: { name: "Armis" },
+    } as never,
+  ]);
+
+  const { recentActivity } = await getAdminDashboardSummary();
+
+  expect(recentActivity).toHaveLength(3);
+  expect(recentActivity[0]).toMatchObject({
+    type: "scan",
+    label: 'Bea completou "Visit Booth"',
+  });
+  expect(recentActivity[1]).toMatchObject({
+    type: "save",
+    label: "Armis guardou Ana",
+  });
+  expect(recentActivity[2]).toMatchObject({
+    type: "signup",
+    label: "Ana juntou-se à Fallstack",
+  });
+});
+
+test("caps the merged feed at 15 events even when more are available", async () => {
+  const many = Array.from({ length: 10 }, (_, i) => ({
+    name: `Student ${i}`,
+    createdAt: new Date(Date.UTC(2026, 6, 28, i)),
+  }));
+  vi.mocked(findRecentStudents).mockResolvedValue(many as never);
+  vi.mocked(findRecentActionCompletions).mockResolvedValue(
+    many.map((s) => ({
+      completedAt: s.createdAt,
+      student: { name: s.name },
+      action: { name: "Action" },
+    })) as never
+  );
+
+  const { recentActivity } = await getAdminDashboardSummary();
+
+  expect(recentActivity).toHaveLength(15);
+});
+
+test("buckets weekly activity by day, including days with zero events", async () => {
+  const today = new Date();
+  today.setHours(12, 0, 0, 0);
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  vi.mocked(findStudentSignupTimestampsSince).mockResolvedValue([
+    { createdAt: today } as never,
+    { createdAt: today } as never,
+  ]);
+  vi.mocked(findActionCompletionTimestampsSince).mockResolvedValue([
+    { completedAt: yesterday } as never,
+  ]);
+
+  const { weeklyActivity } = await getAdminDashboardSummary();
+
+  expect(weeklyActivity).toHaveLength(7);
+  const todayBucket = weeklyActivity.find(
+    (day) => day.date === today.toISOString().slice(0, 10)
+  );
+  const yesterdayBucket = weeklyActivity.find(
+    (day) => day.date === yesterday.toISOString().slice(0, 10)
+  );
+  expect(todayBucket).toMatchObject({ signups: 2, scans: 0, saves: 0 });
+  expect(yesterdayBucket).toMatchObject({ signups: 0, scans: 1, saves: 0 });
+});

--- a/src/application/services/adminDashboardService.ts
+++ b/src/application/services/adminDashboardService.ts
@@ -1,0 +1,159 @@
+import "server-only";
+
+import {
+  countActionCompletions,
+  findActionCompletionTimestampsSince,
+  findRecentActionCompletions,
+} from "../repositories/actionRepository";
+import { countCompaniesForAdmin } from "../repositories/companyRepository";
+import { countEmployeesForAdmin } from "../repositories/employeeRepository";
+import {
+  countAllSavedStudents,
+  findRecentSavedStudents,
+  findSavedStudentTimestampsSince,
+} from "../repositories/savedStudentRepository";
+import {
+  countStudents,
+  findRecentStudents,
+  findStudentSignupTimestampsSince,
+} from "../repositories/studentRepository";
+
+const ACTIVITY_FEED_LIMIT = 15;
+const RECENT_PER_SOURCE = 10;
+const WEEKLY_DAYS = 7;
+
+export type ActivityEventType = "signup" | "scan" | "save";
+
+export interface ActivityEvent {
+  type: ActivityEventType;
+  label: string;
+  timestamp: string;
+}
+
+export interface DailyActivity {
+  date: string;
+  signups: number;
+  scans: number;
+  saves: number;
+}
+
+export interface AdminDashboardSummary {
+  studentCount: number;
+  companyCount: number;
+  employeeCount: number;
+  actionCompletionCount: number;
+  savedStudentCount: number;
+  weeklyActivity: DailyActivity[];
+  recentActivity: ActivityEvent[];
+}
+
+function dayKey(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+// The window is small enough (a single-event fair, not a high-volume
+// product) that fetching raw timestamps and bucketing them here is simpler
+// and more portable than a DB-side date_trunc - see the repository
+// functions' own comments for the same rationale.
+function bucketByDay(timestamps: Date[], days: number) {
+  const buckets = new Map<string, number>();
+  const today = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const day = new Date(today);
+    day.setDate(day.getDate() - i);
+    buckets.set(dayKey(day), 0);
+  }
+  for (const timestamp of timestamps) {
+    const key = dayKey(timestamp);
+    if (buckets.has(key)) buckets.set(key, (buckets.get(key) ?? 0) + 1);
+  }
+  return buckets;
+}
+
+export async function getAdminDashboardSummary(): Promise<AdminDashboardSummary> {
+  const since = new Date();
+  since.setDate(since.getDate() - (WEEKLY_DAYS - 1));
+  since.setHours(0, 0, 0, 0);
+
+  const [
+    studentCount,
+    companyCount,
+    employeeCount,
+    actionCompletionCount,
+    savedStudentCount,
+    recentStudents,
+    recentCompletions,
+    recentSaves,
+    signupTimestamps,
+    completionTimestamps,
+    saveTimestamps,
+  ] = await Promise.all([
+    countStudents(),
+    countCompaniesForAdmin(),
+    countEmployeesForAdmin(),
+    countActionCompletions(),
+    countAllSavedStudents(),
+    findRecentStudents(RECENT_PER_SOURCE),
+    findRecentActionCompletions(RECENT_PER_SOURCE),
+    findRecentSavedStudents(RECENT_PER_SOURCE),
+    findStudentSignupTimestampsSince(since),
+    findActionCompletionTimestampsSince(since),
+    findSavedStudentTimestampsSince(since),
+  ]);
+
+  const events: { type: ActivityEventType; label: string; timestamp: Date }[] =
+    [
+      ...recentStudents.map((student) => ({
+        type: "signup" as const,
+        label: `${student.name} juntou-se à Fallstack`,
+        timestamp: student.createdAt,
+      })),
+      ...recentCompletions.map((completion) => ({
+        type: "scan" as const,
+        label: `${completion.student.name} completou "${completion.action.name}"`,
+        timestamp: completion.completedAt,
+      })),
+      ...recentSaves.map((saved) => ({
+        type: "save" as const,
+        label: `${saved.company.name} guardou ${saved.student.name}`,
+        timestamp: saved.createdAt,
+      })),
+    ]
+      .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
+      .slice(0, ACTIVITY_FEED_LIMIT);
+
+  const signupBuckets = bucketByDay(
+    signupTimestamps.map((s) => s.createdAt),
+    WEEKLY_DAYS
+  );
+  const scanBuckets = bucketByDay(
+    completionTimestamps.map((c) => c.completedAt),
+    WEEKLY_DAYS
+  );
+  const saveBuckets = bucketByDay(
+    saveTimestamps.map((s) => s.createdAt),
+    WEEKLY_DAYS
+  );
+
+  const weeklyActivity: DailyActivity[] = Array.from(signupBuckets.keys()).map(
+    (date) => ({
+      date,
+      signups: signupBuckets.get(date) ?? 0,
+      scans: scanBuckets.get(date) ?? 0,
+      saves: saveBuckets.get(date) ?? 0,
+    })
+  );
+
+  return {
+    studentCount,
+    companyCount,
+    employeeCount,
+    actionCompletionCount,
+    savedStudentCount,
+    weeklyActivity,
+    recentActivity: events.map((event) => ({
+      ...event,
+      timestamp: event.timestamp.toISOString(),
+    })),
+  };
+}

--- a/src/application/services/adminDashboardService.ts
+++ b/src/application/services/adminDashboardService.ts
@@ -19,8 +19,17 @@ import {
 } from "../repositories/studentRepository";
 
 const ACTIVITY_FEED_LIMIT = 15;
-const RECENT_PER_SOURCE = 10;
+// Must be >= ACTIVITY_FEED_LIMIT: any event among the true global top 15
+// (across all 3 sources, by timestamp) is necessarily among its own
+// source's top 15 too - removing events from other sources can only raise
+// or hold an event's rank within its own source, never lower it. Fetching
+// fewer than ACTIVITY_FEED_LIMIT per source can silently drop a genuinely
+// recent event from the source with the most activity (e.g. QR scans
+// spiking during a busy period) and backfill the feed with older events
+// from quieter sources instead.
+const RECENT_PER_SOURCE = ACTIVITY_FEED_LIMIT;
 const WEEKLY_DAYS = 7;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export type ActivityEventType = "signup" | "scan" | "save";
 
@@ -51,17 +60,25 @@ function dayKey(date: Date) {
   return date.toISOString().slice(0, 10);
 }
 
+// Midnight UTC for the given date's UTC calendar day. Everything that
+// builds or compares day buckets goes through this (and dayKey's own
+// toISOString, also UTC) - mixing local-time Date mutators (setDate,
+// setHours) with a UTC-keyed bucket map only happened to work while the
+// process ran with no TZ set (local time == UTC), and would silently
+// off-by-one near midnight the moment that stops being true.
+function startOfUTCDay(date: Date) {
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
 // The window is small enough (a single-event fair, not a high-volume
 // product) that fetching raw timestamps and bucketing them here is simpler
 // and more portable than a DB-side date_trunc - see the repository
 // functions' own comments for the same rationale.
 function bucketByDay(timestamps: Date[], days: number) {
   const buckets = new Map<string, number>();
-  const today = new Date();
+  const todayUTC = startOfUTCDay(new Date());
   for (let i = days - 1; i >= 0; i--) {
-    const day = new Date(today);
-    day.setDate(day.getDate() - i);
-    buckets.set(dayKey(day), 0);
+    buckets.set(dayKey(new Date(todayUTC - i * MS_PER_DAY)), 0);
   }
   for (const timestamp of timestamps) {
     const key = dayKey(timestamp);
@@ -71,9 +88,9 @@ function bucketByDay(timestamps: Date[], days: number) {
 }
 
 export async function getAdminDashboardSummary(): Promise<AdminDashboardSummary> {
-  const since = new Date();
-  since.setDate(since.getDate() - (WEEKLY_DAYS - 1));
-  since.setHours(0, 0, 0, 0);
+  const since = new Date(
+    startOfUTCDay(new Date()) - (WEEKLY_DAYS - 1) * MS_PER_DAY
+  );
 
   const [
     studentCount,

--- a/src/application/services/authApplicationService.test.ts
+++ b/src/application/services/authApplicationService.test.ts
@@ -50,7 +50,7 @@ test("routes an existing student with a profile to their student page", async ()
   vi.mocked(findUserSessionById).mockResolvedValue({
     id: "auth-id-1",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "auth-id-1", code: "S123", name: "Ana" },
     employee: null,
   } as never);
@@ -70,7 +70,7 @@ test("routes an existing employee to the dashboard", async () => {
   vi.mocked(findUserSessionById).mockResolvedValue({
     id: "auth-id-1",
     role: "EMPLOYEE",
-    isAdmin: false,
+    adminRole: null,
     student: null,
     employee: { id: "auth-id-1", name: "Rui", companyId: "c1", company: {} },
   } as never);
@@ -88,7 +88,7 @@ test("falls back to the wizard for a STUDENT role with no profile yet", async ()
   vi.mocked(findUserSessionById).mockResolvedValue({
     id: "auth-id-1",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: null,
     employee: null,
   } as never);
@@ -123,7 +123,7 @@ test("re-keys a confirmed existing password-account student found by email to th
   vi.mocked(findUserSessionByEmail).mockResolvedValue({
     id: "old-password-id",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "old-password-id", code: "S456", name: "Bea" },
     employee: null,
   } as never);
@@ -149,7 +149,7 @@ test("re-keys a confirmed existing password-account employee found by email to t
   vi.mocked(findUserSessionByEmail).mockResolvedValue({
     id: "old-password-id",
     role: "EMPLOYEE",
-    isAdmin: false,
+    adminRole: null,
     student: null,
     employee: {
       id: "old-password-id",
@@ -176,7 +176,7 @@ test("discards an unconfirmed dangling account found by email instead of relinki
   vi.mocked(findUserSessionByEmail).mockResolvedValue({
     id: "spoofed-id",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: { id: "spoofed-id", code: "S999", name: "Attacker-planted" },
     employee: null,
   } as never);
@@ -205,7 +205,7 @@ test("fails closed (treats as unconfirmed) when the admin lookup errors", async 
   vi.mocked(findUserSessionByEmail).mockResolvedValue({
     id: "old-password-id",
     role: "STUDENT",
-    isAdmin: false,
+    adminRole: null,
     student: null,
     employee: null,
   } as never);

--- a/src/application/services/authApplicationService.ts
+++ b/src/application/services/authApplicationService.ts
@@ -52,13 +52,15 @@ async function createSupabaseAuthUser(email: string, password: string) {
 // for later changes; this is only for initial provisioning.
 export async function createSupabaseAuthUserAsAdmin(
   email: string,
-  password: string
+  password: string,
+  displayName?: string
 ) {
   const admin = createAdminClient();
   const { data, error } = await admin.auth.admin.createUser({
     email,
     password,
     email_confirm: true,
+    user_metadata: displayName ? { name: displayName } : undefined,
   });
   if (error || !data.user)
     throw new HttpError(

--- a/src/components/AdminAccountForm/index.tsx
+++ b/src/components/AdminAccountForm/index.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
+
+import { httpClient } from "@/lib/http/client";
+import AdminForm, {
+  type AdminFormSection,
+  type AdminFormValue,
+} from "@/components/AdminForm";
+import type { AdminAccountDto } from "@/application/dto/adminAccountDto";
+
+interface AdminAccountFormProps {
+  admin?: AdminAccountDto;
+}
+
+const roleOptions = [
+  { label: "Admin", value: "ADMIN" },
+  { label: "Super Admin", value: "SUPER_ADMIN" },
+];
+
+const AdminAccountForm: React.FC<AdminAccountFormProps> = ({ admin }) => {
+  const router = useRouter();
+
+  const handleSubmit = async (values: Record<string, AdminFormValue>) => {
+    try {
+      if (admin) {
+        const payload: Record<string, AdminFormValue | null | undefined> = {
+          name: values.name,
+          adminRole: values.adminRole,
+        };
+        if (values.password) payload.password = values.password;
+        await httpClient.patch(`/admin/admins/${admin.id}`, payload);
+        toast.success("Admin atualizado.");
+      } else {
+        await httpClient.post("/admin/admins", {
+          email: values.email,
+          password: values.password,
+          name: values.name,
+          adminRole: values.adminRole,
+        });
+        toast.success("Admin criado.");
+      }
+      router.push("/admins");
+      router.refresh();
+    } catch {
+      toast.error("Não foi possível guardar o admin.");
+    }
+  };
+
+  const sections: AdminFormSection[] = [
+    {
+      kind: "fields",
+      title: "Detalhes",
+      fields: [
+        ...(!admin
+          ? ([
+              {
+                kind: "email",
+                name: "email",
+                label: "Email",
+                required: true,
+              },
+            ] as const)
+          : []),
+        { kind: "text", name: "name", label: "Nome", required: true },
+        {
+          kind: "select",
+          name: "adminRole",
+          label: "Tipo",
+          options: roleOptions,
+          required: true,
+        },
+      ],
+    },
+    {
+      kind: "password",
+      title: admin ? "Alterar palavra-passe" : "Palavra-passe",
+      name: "password",
+    },
+  ];
+
+  return (
+    <AdminForm
+      id={admin?.id}
+      sections={sections}
+      defaultValues={
+        admin
+          ? { name: admin.name, adminRole: admin.adminRole }
+          : { adminRole: "ADMIN" }
+      }
+      onSubmit={handleSubmit}
+    />
+  );
+};
+
+export default AdminAccountForm;

--- a/src/components/AdminActivityFeed/index.tsx
+++ b/src/components/AdminActivityFeed/index.tsx
@@ -1,0 +1,63 @@
+import type { ActivityEvent } from "@/application/services/adminDashboardService";
+
+interface AdminActivityFeedProps {
+  events: ActivityEvent[];
+}
+
+// Same categorical slots as AdminWeeklyActivityChart, kept in sync manually
+// since each event only ever carries one type (a legend would be redundant
+// noise on a list, unlike the chart).
+const TYPE_STYLE: Record<
+  ActivityEvent["type"],
+  { color: string; icon: string }
+> = {
+  signup: { color: "#2a78d6", icon: "👤" },
+  scan: { color: "#eb6834", icon: "📷" },
+  save: { color: "#1baf7a", icon: "⭐" },
+};
+
+function formatRelativeTime(iso: string) {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const minutes = Math.round(diffMs / 60_000);
+  if (minutes < 1) return "agora mesmo";
+  if (minutes < 60) return `há ${minutes} min`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `há ${hours}h`;
+  const days = Math.round(hours / 24);
+  return `há ${days}d`;
+}
+
+const AdminActivityFeed: React.FC<AdminActivityFeedProps> = ({ events }) => (
+  <div className="w-full rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+    <h2 className="mb-4 text-lg font-semibold text-gray-800">
+      Atividade recente
+    </h2>
+
+    {events.length === 0 ? (
+      <p className="text-gray-500">Ainda não há atividade.</p>
+    ) : (
+      <ul className="flex flex-col gap-3">
+        {events.map((event, index) => (
+          <li
+            key={`${event.type}-${event.timestamp}-${index}`}
+            className="flex items-start gap-3 text-sm"
+          >
+            <span
+              className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full text-xs"
+              style={{ backgroundColor: `${TYPE_STYLE[event.type].color}1a` }}
+              aria-hidden="true"
+            >
+              {TYPE_STYLE[event.type].icon}
+            </span>
+            <span className="flex-1 text-gray-700">{event.label}</span>
+            <span className="shrink-0 text-gray-400">
+              {formatRelativeTime(event.timestamp)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+);
+
+export default AdminActivityFeed;

--- a/src/components/AdminSidebar/index.tsx
+++ b/src/components/AdminSidebar/index.tsx
@@ -72,6 +72,21 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({ isSuperAdmin }) => {
       className="sticky top-16 hidden h-[calc(100vh-4rem)] w-56 shrink-0 overflow-y-auto border-r border-gray-200 bg-white p-4 md:block"
     >
       <ul className="flex flex-col gap-6">
+        <li>
+          <Link
+            href="/overview"
+            aria-current={
+              pathname?.startsWith("/overview") ? "page" : undefined
+            }
+            className={`block rounded-md px-2 py-1.5 text-sm font-semibold transition-colors ${
+              pathname?.startsWith("/overview")
+                ? "bg-primary/10 text-primary"
+                : "text-gray-800 hover:bg-gray-100"
+            }`}
+          >
+            Dashboard
+          </Link>
+        </li>
         {sections.map((section) => (
           <li key={section.label}>
             <h2 className="mb-2 px-2 text-xs font-semibold tracking-wider text-gray-400 uppercase">

--- a/src/components/AdminSidebar/index.tsx
+++ b/src/components/AdminSidebar/index.tsx
@@ -15,7 +15,11 @@ interface AdminNavSection {
   items: AdminNavItem[];
 }
 
-const sections: AdminNavSection[] = [
+interface AdminSidebarProps {
+  isSuperAdmin: boolean;
+}
+
+const baseSections: AdminNavSection[] = [
   {
     label: "Users",
     items: [
@@ -49,9 +53,18 @@ const sections: AdminNavSection[] = [
   },
 ];
 
-const AdminSidebar: React.FC = () => {
+const AdminSidebar: React.FC<AdminSidebarProps> = ({ isSuperAdmin }) => {
   const pathname = usePathname();
   const logsUrl = clientEnv.NEXT_PUBLIC_LOGS_DASHBOARD_URL;
+
+  const sections: AdminNavSection[] = baseSections.map((section) =>
+    section.label === "Users" && isSuperAdmin
+      ? {
+          ...section,
+          items: [...section.items, { label: "Admins", href: "/admins" }],
+        }
+      : section
+  );
 
   return (
     <nav

--- a/src/components/AdminStatTile/index.tsx
+++ b/src/components/AdminStatTile/index.tsx
@@ -1,0 +1,15 @@
+interface AdminStatTileProps {
+  label: string;
+  value: number;
+}
+
+const AdminStatTile: React.FC<AdminStatTileProps> = ({ label, value }) => (
+  <div className="w-full rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+    <p className="text-sm text-gray-500">{label}</p>
+    <p className="text-4xl font-bold text-gray-800">
+      {value.toLocaleString("pt-PT")}
+    </p>
+  </div>
+);
+
+export default AdminStatTile;

--- a/src/components/AdminWeeklyActivityChart/index.test.ts
+++ b/src/components/AdminWeeklyActivityChart/index.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+
+import { roundedTopBarPath } from ".";
+
+test("returns null for a zero-height bar instead of a degenerate path", () => {
+  expect(roundedTopBarPath(0, 0, 10, 0)).toBeNull();
+});
+
+test("returns null for a negative height", () => {
+  expect(roundedTopBarPath(0, 0, 10, -5)).toBeNull();
+});
+
+test("draws a rounded-top bar anchored to the chart's baseline", () => {
+  expect(roundedTopBarPath(24, 0, 10, 60)).toBe(
+    "M24,120 V63 Q24,60 27,60 H31 Q34,60 34,63 V120 Z"
+  );
+});
+
+test("clamps the corner radius for a bar shorter than the radius", () => {
+  expect(roundedTopBarPath(0, 0, 10, 0.5)).toBe(
+    "M0,120 V120 Q0,119.5 0.5,119.5 H9.5 Q10,119.5 10,120 V120 Z"
+  );
+});
+
+test("clamps the corner radius for a bar narrower than the radius", () => {
+  expect(roundedTopBarPath(0, 0, 2, 50)).toBe(
+    "M0,120 V71 Q0,70 1,70 H1 Q2,70 2,71 V120 Z"
+  );
+});
+
+test("handles a bar filling the full chart height", () => {
+  expect(roundedTopBarPath(0, 0, 10, 112)).toBe(
+    "M0,120 V11 Q0,8 3,8 H7 Q10,8 10,11 V120 Z"
+  );
+});

--- a/src/components/AdminWeeklyActivityChart/index.tsx
+++ b/src/components/AdminWeeklyActivityChart/index.tsx
@@ -1,0 +1,148 @@
+import type { DailyActivity } from "@/application/services/adminDashboardService";
+
+interface AdminWeeklyActivityChartProps {
+  data: DailyActivity[];
+}
+
+// Categorical slots 1-3 from the design system's validated palette (see the
+// dataviz skill) - the only three that clear the CVD/normal-vision floors
+// under all-pairs comparison in both modes, which is exactly the 3-series
+// case here.
+const SERIES = [
+  { key: "signups" as const, label: "Inscrições", color: "#2a78d6" },
+  { key: "scans" as const, label: "Scans", color: "#eb6834" },
+  { key: "saves" as const, label: "Guardados", color: "#1baf7a" },
+];
+
+const WEEKDAY_LABELS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
+
+const BAR_WIDTH = 10;
+const BAR_GAP = 2;
+const GROUP_GAP = 14;
+const GROUP_WIDTH = SERIES.length * BAR_WIDTH + (SERIES.length - 1) * BAR_GAP;
+const CHART_HEIGHT = 120;
+const LABEL_HEIGHT = 20;
+const RADIUS = 3;
+
+function roundedTopBarPath(
+  x: number,
+  y: number,
+  width: number,
+  height: number
+) {
+  if (height <= 0) return null;
+  const r = Math.min(RADIUS, width / 2, height);
+  const top = y + CHART_HEIGHT - height;
+  const bottom = y + CHART_HEIGHT;
+  return `M${x},${bottom} V${top + r} Q${x},${top} ${x + r},${top} H${x + width - r} Q${x + width},${top} ${x + width},${top + r} V${bottom} Z`;
+}
+
+// A colored bar chart alone leaves the low-contrast slot (aqua "Guardados")
+// hard to read for low-vision users - this table is the "table view exists"
+// mitigation, not a decorative afterthought, and doubles as the exact
+// figures the chart deliberately doesn't label point-by-point.
+const AdminWeeklyActivityChart: React.FC<AdminWeeklyActivityChartProps> = ({
+  data,
+}) => {
+  const max = Math.max(1, ...data.flatMap((d) => SERIES.map((s) => d[s.key])));
+  const totalWidth = data.length * GROUP_WIDTH + (data.length - 1) * GROUP_GAP;
+  const totalHeight = CHART_HEIGHT + LABEL_HEIGHT;
+
+  return (
+    <div className="w-full rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-800">
+          Atividade dos últimos 7 dias
+        </h2>
+        <ul className="flex items-center gap-4 text-sm text-gray-600">
+          {SERIES.map((series) => (
+            <li key={series.key} className="flex items-center gap-1.5">
+              <span
+                className="inline-block size-2.5 rounded-full"
+                style={{ backgroundColor: series.color }}
+              />
+              {series.label}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${totalWidth} ${totalHeight}`}
+        className="h-auto w-full"
+        role="img"
+        aria-label="Gráfico de barras com inscrições, scans e estudantes guardados por dia, nos últimos 7 dias"
+      >
+        <line
+          x1={0}
+          y1={CHART_HEIGHT}
+          x2={totalWidth}
+          y2={CHART_HEIGHT}
+          stroke="#e5e7eb"
+          strokeWidth={1}
+        />
+        {data.map((day, dayIndex) => {
+          const groupX = dayIndex * (GROUP_WIDTH + GROUP_GAP);
+          const weekday = WEEKDAY_LABELS[new Date(day.date).getUTCDay()];
+          return (
+            <g key={day.date}>
+              {SERIES.map((series, seriesIndex) => {
+                const value = day[series.key];
+                const height = (value / max) * (CHART_HEIGHT - 8);
+                const x = groupX + seriesIndex * (BAR_WIDTH + BAR_GAP);
+                const path = roundedTopBarPath(x, 0, BAR_WIDTH, height);
+                return path ? (
+                  <path key={series.key} d={path} fill={series.color} />
+                ) : null;
+              })}
+              <text
+                x={groupX + GROUP_WIDTH / 2}
+                y={CHART_HEIGHT + 14}
+                textAnchor="middle"
+                className="fill-gray-500"
+                fontSize={9}
+              >
+                {weekday}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      <details className="mt-4 text-sm text-gray-600">
+        <summary className="cursor-pointer select-none">
+          Ver como tabela
+        </summary>
+        <table className="mt-2 w-full border-collapse text-left">
+          <caption className="sr-only">
+            Atividade diária dos últimos 7 dias, em números
+          </caption>
+          <thead className="text-xs tracking-wider text-gray-400 uppercase">
+            <tr>
+              <th className="py-1 pr-4">Dia</th>
+              {SERIES.map((series) => (
+                <th key={series.key} className="py-1 pr-4">
+                  {series.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((day) => (
+              <tr key={day.date} className="border-t border-gray-100">
+                <td className="py-1 pr-4">{day.date}</td>
+                {SERIES.map((series) => (
+                  <td key={series.key} className="py-1 pr-4">
+                    {day[series.key]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </details>
+    </div>
+  );
+};
+
+export default AdminWeeklyActivityChart;

--- a/src/components/AdminWeeklyActivityChart/index.tsx
+++ b/src/components/AdminWeeklyActivityChart/index.tsx
@@ -24,7 +24,10 @@ const CHART_HEIGHT = 120;
 const LABEL_HEIGHT = 20;
 const RADIUS = 3;
 
-function roundedTopBarPath(
+// Exported for its own unit test (index.test.ts) - the geometry is easy to
+// get subtly wrong (degenerate zero-height bars, radius bigger than the bar)
+// and worth a real regression guard rather than one-off manual checking.
+export function roundedTopBarPath(
   x: number,
   y: number,
   width: number,

--- a/src/components/Profile/UserButton/index.test.tsx
+++ b/src/components/Profile/UserButton/index.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import type { SessionDto } from "@/application/dto/sessionDto";
+
+import UserButton from ".";
+
+const linkHref = () => screen.getByRole("link").getAttribute("href");
+
+test("links an EMPLOYEE to the dashboard", () => {
+  const user: SessionDto = { role: "EMPLOYEE", adminRole: null, student: null };
+  render(<UserButton user={user} />);
+  expect(linkHref()).toBe("/dashboard");
+});
+
+test("links a STUDENT with a profile to their student page", () => {
+  const user: SessionDto = {
+    role: "STUDENT",
+    adminRole: null,
+    student: { code: "s1", name: "Jane" },
+  };
+  render(<UserButton user={user} />);
+  expect(linkHref()).toBe("/student/s1");
+});
+
+test("links a STUDENT with no profile yet back into signup", () => {
+  const user: SessionDto = { role: "STUDENT", adminRole: null, student: null };
+  render(<UserButton user={user} />);
+  expect(linkHref()).toBe("/signup");
+});
+
+test("links an admin to the backoffice instead of signup, even though role is null", () => {
+  const user: SessionDto = { role: null, adminRole: "ADMIN", student: null };
+  render(<UserButton user={user} />);
+  expect(linkHref()).toBe("/students");
+});
+
+test("links a super admin to the backoffice too", () => {
+  const user: SessionDto = {
+    role: null,
+    adminRole: "SUPER_ADMIN",
+    student: null,
+  };
+  render(<UserButton user={user} />);
+  expect(linkHref()).toBe("/students");
+});

--- a/src/components/Profile/UserButton/index.test.tsx
+++ b/src/components/Profile/UserButton/index.test.tsx
@@ -32,7 +32,7 @@ test("links a STUDENT with no profile yet back into signup", () => {
 test("links an admin to the backoffice instead of signup, even though role is null", () => {
   const user: SessionDto = { role: null, adminRole: "ADMIN", student: null };
   render(<UserButton user={user} />);
-  expect(linkHref()).toBe("/students");
+  expect(linkHref()).toBe("/overview");
 });
 
 test("links a super admin to the backoffice too", () => {
@@ -42,5 +42,5 @@ test("links a super admin to the backoffice too", () => {
     student: null,
   };
   render(<UserButton user={user} />);
-  expect(linkHref()).toBe("/students");
+  expect(linkHref()).toBe("/overview");
 });

--- a/src/components/Profile/UserButton/index.tsx
+++ b/src/components/Profile/UserButton/index.tsx
@@ -18,7 +18,7 @@ const UserButton: React.FC<UserButtonProps> = ({ user }) => {
   // isn't a STUDENT/EMPLOYEE at all) - checked first so it doesn't fall
   // into that same "unfinished student signup" branch.
   const profileUrl = user.adminRole
-    ? "/students"
+    ? "/overview"
     : user.role === "EMPLOYEE"
       ? "/dashboard"
       : user.student

--- a/src/components/Profile/UserButton/index.tsx
+++ b/src/components/Profile/UserButton/index.tsx
@@ -13,9 +13,13 @@ const UserButton: React.FC<UserButtonProps> = ({ user }) => {
   // A STUDENT-role session can exist with no Student row yet - e.g. AuthNEI
   // established the account but the signup wizard was abandoned or
   // interrupted before the profile step. Route back into the wizard to
-  // finish it instead of a dead link.
-  const profileUrl =
-    user.role === "EMPLOYEE"
+  // finish it instead of a dead link. An admin account has role: null and
+  // no student profile either, but for an entirely different reason (it
+  // isn't a STUDENT/EMPLOYEE at all) - checked first so it doesn't fall
+  // into that same "unfinished student signup" branch.
+  const profileUrl = user.adminRole
+    ? "/students"
+    : user.role === "EMPLOYEE"
       ? "/dashboard"
       : user.student
         ? "/student/" + user.student.code

--- a/src/domain/auth/authPolicy.test.ts
+++ b/src/domain/auth/authPolicy.test.ts
@@ -5,7 +5,7 @@ import { AuthPolicySession, passesAuthPolicy } from "./authPolicy";
 
 const studentSession: AuthPolicySession = {
   role: "STUDENT",
-  isAdmin: false,
+  adminRole: null,
   student: { id: "student-1", code: "AB12" },
   employee: null,
 };
@@ -35,7 +35,7 @@ test("student policy requires STUDENT role with a student profile", () => {
 test("employee policy requires EMPLOYEE role with an employee's company", () => {
   const employeeSession: AuthPolicySession = {
     role: "EMPLOYEE",
-    isAdmin: false,
+    adminRole: null,
     student: null,
     employee: { company: { id: "company-1" } },
   };
@@ -53,16 +53,44 @@ test("employee policy requires EMPLOYEE role with an employee's company", () => 
   );
 });
 
-test("admin policy requires session.isAdmin", () => {
+test("admin policy accepts either admin tier", () => {
   assert.equal(
-    passesAuthPolicy("admin", { ...studentSession, isAdmin: true }),
+    passesAuthPolicy("admin", { ...studentSession, adminRole: "ADMIN" }),
+    true
+  );
+  assert.equal(
+    passesAuthPolicy("admin", {
+      ...studentSession,
+      adminRole: "SUPER_ADMIN",
+    }),
     true
   );
   assert.equal(passesAuthPolicy("admin", studentSession), false);
 });
 
+test("superadmin policy requires SUPER_ADMIN specifically", () => {
+  assert.equal(
+    passesAuthPolicy("superadmin", {
+      ...studentSession,
+      adminRole: "SUPER_ADMIN",
+    }),
+    true
+  );
+  assert.equal(
+    passesAuthPolicy("superadmin", { ...studentSession, adminRole: "ADMIN" }),
+    false
+  );
+  assert.equal(passesAuthPolicy("superadmin", studentSession), false);
+});
+
 test("every non-public policy rejects a missing session", () => {
-  for (const policy of ["session", "student", "employee", "admin"] as const) {
+  for (const policy of [
+    "session",
+    "student",
+    "employee",
+    "admin",
+    "superadmin",
+  ] as const) {
     assert.equal(passesAuthPolicy(policy, null), false);
   }
 });

--- a/src/domain/auth/authPolicy.ts
+++ b/src/domain/auth/authPolicy.ts
@@ -1,20 +1,24 @@
 /**
- * "public"    - no session required
- * "session"   - any logged-in user
- * "student"   - logged-in user with a Student profile
- * "employee"  - logged-in user with an Employee profile and a Company
- * "admin"     - logged-in user with session.isAdmin
+ * "public"     - no session required
+ * "session"    - any logged-in user
+ * "student"    - logged-in user with a Student profile
+ * "employee"   - logged-in user with an Employee profile and a Company
+ * "admin"      - logged-in user with session.adminRole set (ADMIN or SUPER_ADMIN)
+ * "superadmin" - logged-in user with session.adminRole === "SUPER_ADMIN"
  */
 export type AuthPolicy =
   | "public"
   | "session"
   | "student"
   | "employee"
-  | "admin";
+  | "admin"
+  | "superadmin";
 
 export interface AuthPolicySession {
-  role: "STUDENT" | "EMPLOYEE";
-  isAdmin: boolean;
+  // Null for an admin-only account - it isn't a STUDENT or EMPLOYEE.
+  role: "STUDENT" | "EMPLOYEE" | null;
+  // Null means not an admin at all. Orthogonal to role, not a narrowing of it.
+  adminRole: "ADMIN" | "SUPER_ADMIN" | null;
   student: unknown;
   employee: { company: unknown } | null;
 }
@@ -30,6 +34,7 @@ export function passesAuthPolicy(
     return session.role === "STUDENT" && !!session.student;
   if (policy === "employee")
     return session.role === "EMPLOYEE" && !!session.employee?.company;
-  if (policy === "admin") return session.isAdmin;
+  if (policy === "admin") return session.adminRole !== null;
+  if (policy === "superadmin") return session.adminRole === "SUPER_ADMIN";
   return false;
 }

--- a/src/schemas/adminAccountSchema.ts
+++ b/src/schemas/adminAccountSchema.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 
+import { EmailSchema } from "@/schemas/customEmailZod";
+
 const adminRoleSchema = z.enum(["ADMIN", "SUPER_ADMIN"]);
 
 export const createAdminAccountSchema = z.object({
-  email: z.email(),
+  email: EmailSchema,
   password: z.string().min(8),
   name: z.string().min(1).max(100),
   adminRole: adminRoleSchema,

--- a/src/schemas/adminAccountSchema.ts
+++ b/src/schemas/adminAccountSchema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+const adminRoleSchema = z.enum(["ADMIN", "SUPER_ADMIN"]);
+
+export const createAdminAccountSchema = z.object({
+  email: z.email(),
+  password: z.string().min(8),
+  name: z.string().min(1).max(100),
+  adminRole: adminRoleSchema,
+});
+
+export const updateAdminAccountSchema = z
+  .object({
+    name: z.string().min(1).max(100),
+    adminRole: adminRoleSchema,
+    password: z.string().min(8),
+    active: z.boolean(),
+  })
+  .partial()
+  .refine((body) => Object.keys(body).length > 0, {
+    message: "At least one field is required",
+  });


### PR DESCRIPTION
## Summary

Closes #269.

Replaces the flat `User.isAdmin` boolean with two admin tiers:
- **Admin** — everything today's admin backoffice already does (Students, Employees, Companies, Sponsors, Actions, Interests, Schedule, FAQs, Storage, Statistics).
- **Super Admin** — everything Admin can do, plus a new Admins section to create/edit/activate/deactivate admin accounts.

## Schema
- `User.isAdmin: Boolean` → `User.adminRole: AdminRole?` (`ADMIN | SUPER_ADMIN`, null = not an admin).
- `User.role` becomes nullable — an admin-only account has no Student/Employee profile, so `role` is genuinely `null` rather than an arbitrary default.
- New `User.name: String?` for an admin account's display name (Student/Employee already have their own `name` on their profile table).
- Migration backfills existing `isAdmin=true` rows to `adminRole=ADMIN` before dropping the old column — **nobody is auto-promoted to Super Admin by this migration.**

## Auth
- `authPolicy.ts` gets a new `"superadmin"` policy (`adminRole === "SUPER_ADMIN"`) alongside the existing `"admin"` one (`adminRole !== null` — either tier, same meaning as the old `isAdmin` check).
- Every existing `session.isAdmin` read across the app (student-visibility checks, giveaway picker, admin storage upload, saved-student dedup, the admin layout gate) now reads `session.adminRole !== null` — same behavior, just the new field.
- `domain/student/studentAccess.ts`'s own `StudentAccess.isAdmin` is untouched — it's an app-level domain concept derived from `adminRole` at each call site, not the DB field itself.

## New: Admin account management (Super Admin only)
- `POST/GET /api/admin/admins`, `PATCH/DELETE /api/admin/admins/[id]` — gated by the new `"superadmin"` policy.
- New `/admins` section in the admin backoffice (only visible in the sidebar, and only reachable, for Super Admins — page-level `notFound()` guard as defense-in-depth alongside the API gate).
- Creation mirrors the existing Employee admin-CRUD pattern: `admin.auth.admin.createUser` with the password set directly (no invite flow), display name passed through to Supabase's `user_metadata`.
- **Safety guard:** a super admin can't deactivate or delete their own account through this panel (would risk locking every admin out) — demoting themselves is still allowed, since that's recoverable by any other super admin.

## Test plan
- [x] `pnpm lint` on all touched/new files
- [x] `pnpm typecheck`
- [x] `pnpm test` — `authPolicy` (new superadmin cases), `boundaries`, `authApplicationService`, the student profile page, every admin-gated route test, `qrcode`, `actions/[id]`, `serviceLogic`, `savedStudentService`, and the new `adminAccountService` suite (create-rollback, self-deactivate/delete guard, self-demote allowed) all green
- [x] Verified the migration against a throwaway local Postgres: seeded a pre-migration `isAdmin=true` row, applied the migration, confirmed it backfilled to `adminRole='ADMIN'` correctly and `prisma migrate diff` shows no drift afterward
- [ ] Live click-through of the new Admins UI — not done in this environment (no real Supabase session available), but every code path is covered by the tests above
