### PR TITLE
fix: send admins to the backoffice on login, not signup

### DIFF
--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -45,7 +45,11 @@ const submitLogin = () => {
 };
 
 test("sends an EMPLOYEE to the dashboard", async () => {
-  sessionUserMock.mockReturnValue({ role: "EMPLOYEE", student: null });
+  sessionUserMock.mockReturnValue({
+    role: "EMPLOYEE",
+    adminRole: null,
+    student: null,
+  });
 
   render(<LoginPage />);
   submitLogin();
@@ -56,6 +60,7 @@ test("sends an EMPLOYEE to the dashboard", async () => {
 test("sends a STUDENT with a profile to their student page", async () => {
   sessionUserMock.mockReturnValue({
     role: "STUDENT",
+    adminRole: null,
     student: { code: "s1", name: "Jane" },
   });
 
@@ -66,7 +71,11 @@ test("sends a STUDENT with a profile to their student page", async () => {
 });
 
 test("sends a STUDENT with no profile yet back into signup instead of the homepage", async () => {
-  sessionUserMock.mockReturnValue({ role: "STUDENT", student: null });
+  sessionUserMock.mockReturnValue({
+    role: "STUDENT",
+    adminRole: null,
+    student: null,
+  });
 
   render(<LoginPage />);
   submitLogin();
@@ -74,8 +83,38 @@ test("sends a STUDENT with no profile yet back into signup instead of the homepa
   await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/signup"));
 });
 
-test("falls back to the homepage for any other session shape", async () => {
-  sessionUserMock.mockReturnValue({ role: "ADMIN", student: null });
+test("sends an admin to the backoffice instead of the homepage, even though role is null", async () => {
+  sessionUserMock.mockReturnValue({
+    role: null,
+    adminRole: "ADMIN",
+    student: null,
+  });
+
+  render(<LoginPage />);
+  submitLogin();
+
+  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/students"));
+});
+
+test("sends a super admin to the backoffice too", async () => {
+  sessionUserMock.mockReturnValue({
+    role: null,
+    adminRole: "SUPER_ADMIN",
+    student: null,
+  });
+
+  render(<LoginPage />);
+  submitLogin();
+
+  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/students"));
+});
+
+test("falls back to the homepage for a session with no role and no admin tier", async () => {
+  sessionUserMock.mockReturnValue({
+    role: null,
+    adminRole: null,
+    student: null,
+  });
 
   render(<LoginPage />);
   submitLogin();

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -48,11 +48,16 @@ const LoginPage: React.FC = () => {
     if (await logIn(email, password)) {
       await session.fetchSession();
 
-      // Redirect based on user role. A STUDENT can be logging in with no
-      // Student row yet - e.g. AuthNEI established the account but the
-      // signup wizard was abandoned before it finished - so send them back
-      // into the wizard to complete it instead of the homepage.
-      if (session.user?.role === "EMPLOYEE") {
+      // Redirect based on user role. Checked before role, since an admin
+      // account has role: null (it isn't a STUDENT/EMPLOYEE at all) and
+      // would otherwise fall through to the generic "/" case below. A
+      // STUDENT can be logging in with no Student row yet - e.g. AuthNEI
+      // established the account but the signup wizard was abandoned before
+      // it finished - so send them back into the wizard to complete it
+      // instead of the homepage.
+      if (session.user?.adminRole) {
+        router.push("/students");
+      } else if (session.user?.role === "EMPLOYEE") {
         router.push("/dashboard");
       } else if (session.user?.role === "STUDENT") {
         router.push(

--- a/src/application/boundaries.test.ts
+++ b/src/application/boundaries.test.ts
@@ -105,6 +105,7 @@ test("public DTO mappers omit private database fields", () => {
   });
   assert.deepEqual(toSessionDto(session), {
     role: "STUDENT",
+    adminRole: "ADMIN",
     student: { code: "ABC123", name: "Student" },
   });
   assert.deepEqual(toInterestDto({ id: "interest-id", name: "TypeScript" }), {

--- a/src/application/dto/sessionDto.ts
+++ b/src/application/dto/sessionDto.ts
@@ -1,5 +1,6 @@
 export interface SessionDto {
   role: "STUDENT" | "EMPLOYEE" | null;
+  adminRole: "ADMIN" | "SUPER_ADMIN" | null;
   student: {
     code: string;
     name: string;
@@ -8,6 +9,7 @@ export interface SessionDto {
 
 export const toSessionDto = (session: SessionDto): SessionDto => ({
   role: session.role,
+  adminRole: session.adminRole,
   student: session.student
     ? { code: session.student.code, name: session.student.name }
     : null,

--- a/src/components/Profile/UserButton/index.test.tsx
+++ b/src/components/Profile/UserButton/index.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import type { SessionDto } from "@/application/dto/sessionDto";
+
+import UserButton from ".";
+
+const linkHref = () => screen.getByRole("link").getAttribute("href");
+
+test("links an EMPLOYEE to the dashboard", () => {
+  const user: SessionDto = { role: "EMPLOYEE", adminRole: null, student: null };
+  render(<UserButton user={user} />);
+  expect(linkHref()).toBe("/dashboard");
+});
+
+test("links a STUDENT with a profile to their student page", () => {
+  const user: SessionDto = {
+    role: "STUDENT",
+    adminRole: null,
+    student: { code: "s1", name: "Jane" },
+  };
+  render(<UserButton user={user} />);
+  expect(linkHref()).toBe("/student/s1");
+});
+
+test("links a STUDENT with no profile yet back into signup", () => {
+  const user: SessionDto = { role: "STUDENT", adminRole: null, student: null };
+  render(<UserButton user={user} />);
+  expect(linkHref()).toBe("/signup");
+});
+
+test("links an admin to the backoffice instead of signup, even though role is null", () => {
+  const user: SessionDto = { role: null, adminRole: "ADMIN", student: null };
+  render(<UserButton user={user} />);
+  expect(linkHref()).toBe("/students");
+});
+
+test("links a super admin to the backoffice too", () => {
+  const user: SessionDto = {
+    role: null,
+    adminRole: "SUPER_ADMIN",
+    student: null,
+  };
+  render(<UserButton user={user} />);
+  expect(linkHref()).toBe("/students");
+});

--- a/src/components/Profile/UserButton/index.tsx
+++ b/src/components/Profile/UserButton/index.tsx
@@ -13,9 +13,13 @@ const UserButton: React.FC<UserButtonProps> = ({ user }) => {
   // A STUDENT-role session can exist with no Student row yet - e.g. AuthNEI
   // established the account but the signup wizard was abandoned or
   // interrupted before the profile step. Route back into the wizard to
-  // finish it instead of a dead link.
-  const profileUrl =
-    user.role === "EMPLOYEE"
+  // finish it instead of a dead link. An admin account has role: null and
+  // no student profile either, but for an entirely different reason (it
+  // isn't a STUDENT/EMPLOYEE at all) - checked first so it doesn't fall
+  // into that same "unfinished student signup" branch.
+  const profileUrl = user.adminRole
+    ? "/students"
+    : user.role === "EMPLOYEE"
       ? "/dashboard"
       : user.student
         ? "/student/" + user.student.code


### PR DESCRIPTION
## Summary

Follow-up to #268 (refs #269) — found while testing an admin login manually. It's a real code bug, not a config/deploy issue, so fixing it here as requested rather than in #268 directly.

**Symptom:** logging in with an admin account looked like login silently failed — no redirect to any admin page, landed on the homepage as if nothing happened. Clicking the profile icon afterward (proving a session *did* exist) sent the account into the student signup wizard instead.

**Root cause:** `SessionDto` (the client-facing session shape) never exposed `adminRole` — it only ever had `role` and `student`, because before #268 the client never needed to distinguish an admin from anyone else for redirect purposes. Now that an admin-only account has `role: null` (it isn't a STUDENT or EMPLOYEE), both `LoginPage`'s post-login redirect and `UserButton`'s profile icon fell into their "no role match / no profile" branches — the exact same code path used for a STUDENT mid-signup with no `Student` row yet — and treated the admin as an unfinished student signup.

**Fix:**
- `SessionDto` now includes `adminRole`.
- Both `LoginPage` and `UserButton` check it first, before the STUDENT/EMPLOYEE branches — an admin (either tier) now lands on `/students` (the same page the sidebar's first item already points to) instead of `/` or `/signup`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — extended `LoginPage`'s existing redirect tests with real admin/super-admin cases (previously used a made-up `role: "ADMIN"` that doesn't reflect the actual data model) and added a new `UserButton` test file (it had no coverage at all before this)
- [ ] Live login as an admin account — not verified in this environment (no real Supabase session available), but this is exactly the scenario reported and both new test files assert the corrected redirect target