### PR TITLE
feat: add admin overview dashboard

### DIFF
--- a/src/app/(admin)/overview/page.tsx
+++ b/src/app/(admin)/overview/page.tsx
@@ -1,0 +1,34 @@
+import AdminActivityFeed from "@/components/AdminActivityFeed";
+import AdminStatTile from "@/components/AdminStatTile";
+import AdminWeeklyActivityChart from "@/components/AdminWeeklyActivityChart";
+import { getAdminDashboardSummary } from "@/application/services/adminDashboardService";
+
+const OverviewPage = async () => {
+  const summary = await getAdminDashboardSummary();
+
+  const tiles = [
+    { label: "Estudantes", value: summary.studentCount },
+    { label: "Empresas", value: summary.companyCount },
+    { label: "Recrutadores", value: summary.employeeCount },
+    { label: "Ações completadas", value: summary.actionCompletionCount },
+    { label: "Estudantes guardados", value: summary.savedStudentCount },
+  ];
+
+  return (
+    <section className="flex flex-col gap-6 p-8">
+      <h1 className="text-2xl font-bold text-gray-800">Dashboard</h1>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        {tiles.map((tile) => (
+          <AdminStatTile key={tile.label} {...tile} />
+        ))}
+      </div>
+
+      <AdminWeeklyActivityChart data={summary.weeklyActivity} />
+
+      <AdminActivityFeed events={summary.recentActivity} />
+    </section>
+  );
+};
+
+export default OverviewPage;

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -93,7 +93,7 @@ test("sends an admin to the backoffice instead of the homepage, even though role
   render(<LoginPage />);
   submitLogin();
 
-  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/students"));
+  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/overview"));
 });
 
 test("sends a super admin to the backoffice too", async () => {
@@ -106,7 +106,7 @@ test("sends a super admin to the backoffice too", async () => {
   render(<LoginPage />);
   submitLogin();
 
-  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/students"));
+  await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/overview"));
 });
 
 test("falls back to the homepage for a session with no role and no admin tier", async () => {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -56,7 +56,7 @@ const LoginPage: React.FC = () => {
       // it finished - so send them back into the wizard to complete it
       // instead of the homepage.
       if (session.user?.adminRole) {
-        router.push("/students");
+        router.push("/overview");
       } else if (session.user?.role === "EMPLOYEE") {
         router.push("/dashboard");
       } else if (session.user?.role === "STUDENT") {

--- a/src/application/repositories/actionRepository.ts
+++ b/src/application/repositories/actionRepository.ts
@@ -97,3 +97,26 @@ export const upsertActionCompletion = (
 
 export const toggleAction = (id: string, isLive: boolean) =>
   prisma.action.update({ where: { id }, data: { isLive } });
+
+export const countActionCompletions = () => prisma.actionCompletion.count();
+
+export const findRecentActionCompletions = (limit: number) =>
+  prisma.actionCompletion.findMany({
+    orderBy: { completedAt: "desc" },
+    take: limit,
+    select: {
+      completedAt: true,
+      student: { select: { name: true } },
+      action: { select: { name: true } },
+    },
+  });
+
+// Bucketing by day happens in the service layer - this just returns the raw
+// timestamps for the window, which is small enough (a single-event fair, not
+// a high-volume product) that fetching rows and grouping in JS is simpler
+// and more portable than a DB-side date_trunc.
+export const findActionCompletionTimestampsSince = (since: Date) =>
+  prisma.actionCompletion.findMany({
+    where: { completedAt: { gte: since } },
+    select: { completedAt: true },
+  });

--- a/src/application/repositories/savedStudentRepository.ts
+++ b/src/application/repositories/savedStudentRepository.ts
@@ -60,6 +60,27 @@ export const countCompanySaves = (companyId: string) =>
 export const countSavedStudentsByCompany = () =>
   prisma.savedStudent.groupBy({ by: ["companyId"], _count: { _all: true } });
 
+export const countAllSavedStudents = () => prisma.savedStudent.count();
+
+export const findRecentSavedStudents = (limit: number) =>
+  prisma.savedStudent.findMany({
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: {
+      createdAt: true,
+      student: { select: { name: true } },
+      company: { select: { name: true } },
+    },
+  });
+
+// See findActionCompletionTimestampsSince's comment - same small-scale
+// rationale for bucketing in the service layer instead of DB-side.
+export const findSavedStudentTimestampsSince = (since: Date) =>
+  prisma.savedStudent.findMany({
+    where: { createdAt: { gte: since } },
+    select: { createdAt: true },
+  });
+
 export const findCompanyHistory = (companyId: string) =>
   prisma.savedStudent.findMany({
     where: { companyId },

--- a/src/application/repositories/studentRepository.ts
+++ b/src/application/repositories/studentRepository.ts
@@ -82,6 +82,23 @@ export const updateStudentCv = (
 export const countStudents = () =>
   prisma.student.count({ where: { user: { AND: [{ role: "STUDENT" }] } } });
 
+export const findRecentStudents = (limit: number) =>
+  prisma.student.findMany({
+    where: { user: { role: "STUDENT" } },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: { name: true, createdAt: true },
+  });
+
+// See actionRepository's findActionCompletionTimestampsSince comment - same
+// small-scale rationale for bucketing in the service layer instead of
+// DB-side.
+export const findStudentSignupTimestampsSince = (since: Date) =>
+  prisma.student.findMany({
+    where: { user: { role: "STUDENT" }, createdAt: { gte: since } },
+    select: { createdAt: true },
+  });
+
 export const findAllStudents = () =>
   prisma.student.findMany({
     where: { user: { AND: [{ role: "STUDENT" }] } },

--- a/src/application/services/adminDashboardService.test.ts
+++ b/src/application/services/adminDashboardService.test.ts
@@ -103,6 +103,35 @@ test("merges the three activity sources into one feed, newest first", async () =
   });
 });
 
+test("fetches at least 15 events per source, so a single busy source can't hide a true top-15 event", async () => {
+  await getAdminDashboardSummary();
+
+  expect(findRecentStudents).toHaveBeenCalledWith(15);
+  expect(findRecentActionCompletions).toHaveBeenCalledWith(15);
+  expect(findRecentSavedStudents).toHaveBeenCalledWith(15);
+});
+
+test("doesn't drop the true most-recent events when one source is far busier than the others", async () => {
+  // 15 scans, all newer than every signup/save below - the real top 15.
+  const scans = Array.from({ length: 15 }, (_, i) => ({
+    completedAt: new Date(Date.UTC(2026, 6, 28, 12, i)),
+    student: { name: `Scanner ${i}` },
+    action: { name: "Visit Booth" },
+  }));
+  // Older events that must NOT displace any of the scans above.
+  const olderSignups = Array.from({ length: 5 }, (_, i) => ({
+    name: `Student ${i}`,
+    createdAt: new Date(Date.UTC(2026, 6, 27, 12, i)),
+  }));
+  vi.mocked(findRecentActionCompletions).mockResolvedValue(scans as never);
+  vi.mocked(findRecentStudents).mockResolvedValue(olderSignups as never);
+
+  const { recentActivity } = await getAdminDashboardSummary();
+
+  expect(recentActivity).toHaveLength(15);
+  expect(recentActivity.every((event) => event.type === "scan")).toBe(true);
+});
+
 test("caps the merged feed at 15 events even when more are available", async () => {
   const many = Array.from({ length: 10 }, (_, i) => ({
     name: `Student ${i}`,

--- a/src/application/services/adminDashboardService.test.ts
+++ b/src/application/services/adminDashboardService.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+import {
+  countActionCompletions,
+  findActionCompletionTimestampsSince,
+  findRecentActionCompletions,
+} from "../repositories/actionRepository";
+import { countCompaniesForAdmin } from "../repositories/companyRepository";
+import { countEmployeesForAdmin } from "../repositories/employeeRepository";
+import {
+  countAllSavedStudents,
+  findRecentSavedStudents,
+  findSavedStudentTimestampsSince,
+} from "../repositories/savedStudentRepository";
+import {
+  countStudents,
+  findRecentStudents,
+  findStudentSignupTimestampsSince,
+} from "../repositories/studentRepository";
+import { getAdminDashboardSummary } from "./adminDashboardService";
+
+vi.mock("server-only", () => ({}));
+vi.mock("../repositories/actionRepository", () => ({
+  countActionCompletions: vi.fn(),
+  findActionCompletionTimestampsSince: vi.fn(),
+  findRecentActionCompletions: vi.fn(),
+}));
+vi.mock("../repositories/companyRepository", () => ({
+  countCompaniesForAdmin: vi.fn(),
+}));
+vi.mock("../repositories/employeeRepository", () => ({
+  countEmployeesForAdmin: vi.fn(),
+}));
+vi.mock("../repositories/savedStudentRepository", () => ({
+  countAllSavedStudents: vi.fn(),
+  findRecentSavedStudents: vi.fn(),
+  findSavedStudentTimestampsSince: vi.fn(),
+}));
+vi.mock("../repositories/studentRepository", () => ({
+  countStudents: vi.fn(),
+  findRecentStudents: vi.fn(),
+  findStudentSignupTimestampsSince: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(countStudents).mockResolvedValue(10);
+  vi.mocked(countCompaniesForAdmin).mockResolvedValue(3);
+  vi.mocked(countEmployeesForAdmin).mockResolvedValue(5);
+  vi.mocked(countActionCompletions).mockResolvedValue(20);
+  vi.mocked(countAllSavedStudents).mockResolvedValue(7);
+  vi.mocked(findRecentStudents).mockResolvedValue([]);
+  vi.mocked(findRecentActionCompletions).mockResolvedValue([]);
+  vi.mocked(findRecentSavedStudents).mockResolvedValue([]);
+  vi.mocked(findStudentSignupTimestampsSince).mockResolvedValue([]);
+  vi.mocked(findActionCompletionTimestampsSince).mockResolvedValue([]);
+  vi.mocked(findSavedStudentTimestampsSince).mockResolvedValue([]);
+});
+
+test("passes the raw counts straight through", async () => {
+  const summary = await getAdminDashboardSummary();
+
+  expect(summary.studentCount).toBe(10);
+  expect(summary.companyCount).toBe(3);
+  expect(summary.employeeCount).toBe(5);
+  expect(summary.actionCompletionCount).toBe(20);
+  expect(summary.savedStudentCount).toBe(7);
+});
+
+test("merges the three activity sources into one feed, newest first", async () => {
+  vi.mocked(findRecentStudents).mockResolvedValue([
+    { name: "Ana", createdAt: new Date("2026-07-27T10:00:00Z") } as never,
+  ]);
+  vi.mocked(findRecentActionCompletions).mockResolvedValue([
+    {
+      completedAt: new Date("2026-07-28T09:00:00Z"),
+      student: { name: "Bea" },
+      action: { name: "Visit Booth" },
+    } as never,
+  ]);
+  vi.mocked(findRecentSavedStudents).mockResolvedValue([
+    {
+      createdAt: new Date("2026-07-27T15:00:00Z"),
+      student: { name: "Ana" },
+      company: { name: "Armis" },
+    } as never,
+  ]);
+
+  const { recentActivity } = await getAdminDashboardSummary();
+
+  expect(recentActivity).toHaveLength(3);
+  expect(recentActivity[0]).toMatchObject({
+    type: "scan",
+    label: 'Bea completou "Visit Booth"',
+  });
+  expect(recentActivity[1]).toMatchObject({
+    type: "save",
+    label: "Armis guardou Ana",
+  });
+  expect(recentActivity[2]).toMatchObject({
+    type: "signup",
+    label: "Ana juntou-se à Fallstack",
+  });
+});
+
+test("caps the merged feed at 15 events even when more are available", async () => {
+  const many = Array.from({ length: 10 }, (_, i) => ({
+    name: `Student ${i}`,
+    createdAt: new Date(Date.UTC(2026, 6, 28, i)),
+  }));
+  vi.mocked(findRecentStudents).mockResolvedValue(many as never);
+  vi.mocked(findRecentActionCompletions).mockResolvedValue(
+    many.map((s) => ({
+      completedAt: s.createdAt,
+      student: { name: s.name },
+      action: { name: "Action" },
+    })) as never
+  );
+
+  const { recentActivity } = await getAdminDashboardSummary();
+
+  expect(recentActivity).toHaveLength(15);
+});
+
+test("buckets weekly activity by day, including days with zero events", async () => {
+  const today = new Date();
+  today.setHours(12, 0, 0, 0);
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  vi.mocked(findStudentSignupTimestampsSince).mockResolvedValue([
+    { createdAt: today } as never,
+    { createdAt: today } as never,
+  ]);
+  vi.mocked(findActionCompletionTimestampsSince).mockResolvedValue([
+    { completedAt: yesterday } as never,
+  ]);
+
+  const { weeklyActivity } = await getAdminDashboardSummary();
+
+  expect(weeklyActivity).toHaveLength(7);
+  const todayBucket = weeklyActivity.find(
+    (day) => day.date === today.toISOString().slice(0, 10)
+  );
+  const yesterdayBucket = weeklyActivity.find(
+    (day) => day.date === yesterday.toISOString().slice(0, 10)
+  );
+  expect(todayBucket).toMatchObject({ signups: 2, scans: 0, saves: 0 });
+  expect(yesterdayBucket).toMatchObject({ signups: 0, scans: 1, saves: 0 });
+});

--- a/src/application/services/adminDashboardService.ts
+++ b/src/application/services/adminDashboardService.ts
@@ -1,0 +1,159 @@
+import "server-only";
+
+import {
+  countActionCompletions,
+  findActionCompletionTimestampsSince,
+  findRecentActionCompletions,
+} from "../repositories/actionRepository";
+import { countCompaniesForAdmin } from "../repositories/companyRepository";
+import { countEmployeesForAdmin } from "../repositories/employeeRepository";
+import {
+  countAllSavedStudents,
+  findRecentSavedStudents,
+  findSavedStudentTimestampsSince,
+} from "../repositories/savedStudentRepository";
+import {
+  countStudents,
+  findRecentStudents,
+  findStudentSignupTimestampsSince,
+} from "../repositories/studentRepository";
+
+const ACTIVITY_FEED_LIMIT = 15;
+const RECENT_PER_SOURCE = 10;
+const WEEKLY_DAYS = 7;
+
+export type ActivityEventType = "signup" | "scan" | "save";
+
+export interface ActivityEvent {
+  type: ActivityEventType;
+  label: string;
+  timestamp: string;
+}
+
+export interface DailyActivity {
+  date: string;
+  signups: number;
+  scans: number;
+  saves: number;
+}
+
+export interface AdminDashboardSummary {
+  studentCount: number;
+  companyCount: number;
+  employeeCount: number;
+  actionCompletionCount: number;
+  savedStudentCount: number;
+  weeklyActivity: DailyActivity[];
+  recentActivity: ActivityEvent[];
+}
+
+function dayKey(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+// The window is small enough (a single-event fair, not a high-volume
+// product) that fetching raw timestamps and bucketing them here is simpler
+// and more portable than a DB-side date_trunc - see the repository
+// functions' own comments for the same rationale.
+function bucketByDay(timestamps: Date[], days: number) {
+  const buckets = new Map<string, number>();
+  const today = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const day = new Date(today);
+    day.setDate(day.getDate() - i);
+    buckets.set(dayKey(day), 0);
+  }
+  for (const timestamp of timestamps) {
+    const key = dayKey(timestamp);
+    if (buckets.has(key)) buckets.set(key, (buckets.get(key) ?? 0) + 1);
+  }
+  return buckets;
+}
+
+export async function getAdminDashboardSummary(): Promise<AdminDashboardSummary> {
+  const since = new Date();
+  since.setDate(since.getDate() - (WEEKLY_DAYS - 1));
+  since.setHours(0, 0, 0, 0);
+
+  const [
+    studentCount,
+    companyCount,
+    employeeCount,
+    actionCompletionCount,
+    savedStudentCount,
+    recentStudents,
+    recentCompletions,
+    recentSaves,
+    signupTimestamps,
+    completionTimestamps,
+    saveTimestamps,
+  ] = await Promise.all([
+    countStudents(),
+    countCompaniesForAdmin(),
+    countEmployeesForAdmin(),
+    countActionCompletions(),
+    countAllSavedStudents(),
+    findRecentStudents(RECENT_PER_SOURCE),
+    findRecentActionCompletions(RECENT_PER_SOURCE),
+    findRecentSavedStudents(RECENT_PER_SOURCE),
+    findStudentSignupTimestampsSince(since),
+    findActionCompletionTimestampsSince(since),
+    findSavedStudentTimestampsSince(since),
+  ]);
+
+  const events: { type: ActivityEventType; label: string; timestamp: Date }[] =
+    [
+      ...recentStudents.map((student) => ({
+        type: "signup" as const,
+        label: `${student.name} juntou-se à Fallstack`,
+        timestamp: student.createdAt,
+      })),
+      ...recentCompletions.map((completion) => ({
+        type: "scan" as const,
+        label: `${completion.student.name} completou "${completion.action.name}"`,
+        timestamp: completion.completedAt,
+      })),
+      ...recentSaves.map((saved) => ({
+        type: "save" as const,
+        label: `${saved.company.name} guardou ${saved.student.name}`,
+        timestamp: saved.createdAt,
+      })),
+    ]
+      .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
+      .slice(0, ACTIVITY_FEED_LIMIT);
+
+  const signupBuckets = bucketByDay(
+    signupTimestamps.map((s) => s.createdAt),
+    WEEKLY_DAYS
+  );
+  const scanBuckets = bucketByDay(
+    completionTimestamps.map((c) => c.completedAt),
+    WEEKLY_DAYS
+  );
+  const saveBuckets = bucketByDay(
+    saveTimestamps.map((s) => s.createdAt),
+    WEEKLY_DAYS
+  );
+
+  const weeklyActivity: DailyActivity[] = Array.from(signupBuckets.keys()).map(
+    (date) => ({
+      date,
+      signups: signupBuckets.get(date) ?? 0,
+      scans: scanBuckets.get(date) ?? 0,
+      saves: saveBuckets.get(date) ?? 0,
+    })
+  );
+
+  return {
+    studentCount,
+    companyCount,
+    employeeCount,
+    actionCompletionCount,
+    savedStudentCount,
+    weeklyActivity,
+    recentActivity: events.map((event) => ({
+      ...event,
+      timestamp: event.timestamp.toISOString(),
+    })),
+  };
+}

--- a/src/application/services/adminDashboardService.ts
+++ b/src/application/services/adminDashboardService.ts
@@ -19,8 +19,17 @@ import {
 } from "../repositories/studentRepository";
 
 const ACTIVITY_FEED_LIMIT = 15;
-const RECENT_PER_SOURCE = 10;
+// Must be >= ACTIVITY_FEED_LIMIT: any event among the true global top 15
+// (across all 3 sources, by timestamp) is necessarily among its own
+// source's top 15 too - removing events from other sources can only raise
+// or hold an event's rank within its own source, never lower it. Fetching
+// fewer than ACTIVITY_FEED_LIMIT per source can silently drop a genuinely
+// recent event from the source with the most activity (e.g. QR scans
+// spiking during a busy period) and backfill the feed with older events
+// from quieter sources instead.
+const RECENT_PER_SOURCE = ACTIVITY_FEED_LIMIT;
 const WEEKLY_DAYS = 7;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export type ActivityEventType = "signup" | "scan" | "save";
 
@@ -51,17 +60,25 @@ function dayKey(date: Date) {
   return date.toISOString().slice(0, 10);
 }
 
+// Midnight UTC for the given date's UTC calendar day. Everything that
+// builds or compares day buckets goes through this (and dayKey's own
+// toISOString, also UTC) - mixing local-time Date mutators (setDate,
+// setHours) with a UTC-keyed bucket map only happened to work while the
+// process ran with no TZ set (local time == UTC), and would silently
+// off-by-one near midnight the moment that stops being true.
+function startOfUTCDay(date: Date) {
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
 // The window is small enough (a single-event fair, not a high-volume
 // product) that fetching raw timestamps and bucketing them here is simpler
 // and more portable than a DB-side date_trunc - see the repository
 // functions' own comments for the same rationale.
 function bucketByDay(timestamps: Date[], days: number) {
   const buckets = new Map<string, number>();
-  const today = new Date();
+  const todayUTC = startOfUTCDay(new Date());
   for (let i = days - 1; i >= 0; i--) {
-    const day = new Date(today);
-    day.setDate(day.getDate() - i);
-    buckets.set(dayKey(day), 0);
+    buckets.set(dayKey(new Date(todayUTC - i * MS_PER_DAY)), 0);
   }
   for (const timestamp of timestamps) {
     const key = dayKey(timestamp);
@@ -71,9 +88,9 @@ function bucketByDay(timestamps: Date[], days: number) {
 }
 
 export async function getAdminDashboardSummary(): Promise<AdminDashboardSummary> {
-  const since = new Date();
-  since.setDate(since.getDate() - (WEEKLY_DAYS - 1));
-  since.setHours(0, 0, 0, 0);
+  const since = new Date(
+    startOfUTCDay(new Date()) - (WEEKLY_DAYS - 1) * MS_PER_DAY
+  );
 
   const [
     studentCount,

--- a/src/components/AdminActivityFeed/index.tsx
+++ b/src/components/AdminActivityFeed/index.tsx
@@ -1,0 +1,63 @@
+import type { ActivityEvent } from "@/application/services/adminDashboardService";
+
+interface AdminActivityFeedProps {
+  events: ActivityEvent[];
+}
+
+// Same categorical slots as AdminWeeklyActivityChart, kept in sync manually
+// since each event only ever carries one type (a legend would be redundant
+// noise on a list, unlike the chart).
+const TYPE_STYLE: Record<
+  ActivityEvent["type"],
+  { color: string; icon: string }
+> = {
+  signup: { color: "#2a78d6", icon: "👤" },
+  scan: { color: "#eb6834", icon: "📷" },
+  save: { color: "#1baf7a", icon: "⭐" },
+};
+
+function formatRelativeTime(iso: string) {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const minutes = Math.round(diffMs / 60_000);
+  if (minutes < 1) return "agora mesmo";
+  if (minutes < 60) return `há ${minutes} min`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `há ${hours}h`;
+  const days = Math.round(hours / 24);
+  return `há ${days}d`;
+}
+
+const AdminActivityFeed: React.FC<AdminActivityFeedProps> = ({ events }) => (
+  <div className="w-full rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+    <h2 className="mb-4 text-lg font-semibold text-gray-800">
+      Atividade recente
+    </h2>
+
+    {events.length === 0 ? (
+      <p className="text-gray-500">Ainda não há atividade.</p>
+    ) : (
+      <ul className="flex flex-col gap-3">
+        {events.map((event, index) => (
+          <li
+            key={`${event.type}-${event.timestamp}-${index}`}
+            className="flex items-start gap-3 text-sm"
+          >
+            <span
+              className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full text-xs"
+              style={{ backgroundColor: `${TYPE_STYLE[event.type].color}1a` }}
+              aria-hidden="true"
+            >
+              {TYPE_STYLE[event.type].icon}
+            </span>
+            <span className="flex-1 text-gray-700">{event.label}</span>
+            <span className="shrink-0 text-gray-400">
+              {formatRelativeTime(event.timestamp)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+);
+
+export default AdminActivityFeed;

--- a/src/components/AdminSidebar/index.tsx
+++ b/src/components/AdminSidebar/index.tsx
@@ -72,6 +72,21 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({ isSuperAdmin }) => {
       className="sticky top-16 hidden h-[calc(100vh-4rem)] w-56 shrink-0 overflow-y-auto border-r border-gray-200 bg-white p-4 md:block"
     >
       <ul className="flex flex-col gap-6">
+        <li>
+          <Link
+            href="/overview"
+            aria-current={
+              pathname?.startsWith("/overview") ? "page" : undefined
+            }
+            className={`block rounded-md px-2 py-1.5 text-sm font-semibold transition-colors ${
+              pathname?.startsWith("/overview")
+                ? "bg-primary/10 text-primary"
+                : "text-gray-800 hover:bg-gray-100"
+            }`}
+          >
+            Dashboard
+          </Link>
+        </li>
         {sections.map((section) => (
           <li key={section.label}>
             <h2 className="mb-2 px-2 text-xs font-semibold tracking-wider text-gray-400 uppercase">

--- a/src/components/AdminStatTile/index.tsx
+++ b/src/components/AdminStatTile/index.tsx
@@ -1,0 +1,15 @@
+interface AdminStatTileProps {
+  label: string;
+  value: number;
+}
+
+const AdminStatTile: React.FC<AdminStatTileProps> = ({ label, value }) => (
+  <div className="w-full rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+    <p className="text-sm text-gray-500">{label}</p>
+    <p className="text-4xl font-bold text-gray-800">
+      {value.toLocaleString("pt-PT")}
+    </p>
+  </div>
+);
+
+export default AdminStatTile;

--- a/src/components/AdminWeeklyActivityChart/index.test.ts
+++ b/src/components/AdminWeeklyActivityChart/index.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+
+import { roundedTopBarPath } from ".";
+
+test("returns null for a zero-height bar instead of a degenerate path", () => {
+  expect(roundedTopBarPath(0, 0, 10, 0)).toBeNull();
+});
+
+test("returns null for a negative height", () => {
+  expect(roundedTopBarPath(0, 0, 10, -5)).toBeNull();
+});
+
+test("draws a rounded-top bar anchored to the chart's baseline", () => {
+  expect(roundedTopBarPath(24, 0, 10, 60)).toBe(
+    "M24,120 V63 Q24,60 27,60 H31 Q34,60 34,63 V120 Z"
+  );
+});
+
+test("clamps the corner radius for a bar shorter than the radius", () => {
+  expect(roundedTopBarPath(0, 0, 10, 0.5)).toBe(
+    "M0,120 V120 Q0,119.5 0.5,119.5 H9.5 Q10,119.5 10,120 V120 Z"
+  );
+});
+
+test("clamps the corner radius for a bar narrower than the radius", () => {
+  expect(roundedTopBarPath(0, 0, 2, 50)).toBe(
+    "M0,120 V71 Q0,70 1,70 H1 Q2,70 2,71 V120 Z"
+  );
+});
+
+test("handles a bar filling the full chart height", () => {
+  expect(roundedTopBarPath(0, 0, 10, 112)).toBe(
+    "M0,120 V11 Q0,8 3,8 H7 Q10,8 10,11 V120 Z"
+  );
+});

--- a/src/components/AdminWeeklyActivityChart/index.tsx
+++ b/src/components/AdminWeeklyActivityChart/index.tsx
@@ -1,0 +1,148 @@
+import type { DailyActivity } from "@/application/services/adminDashboardService";
+
+interface AdminWeeklyActivityChartProps {
+  data: DailyActivity[];
+}
+
+// Categorical slots 1-3 from the design system's validated palette (see the
+// dataviz skill) - the only three that clear the CVD/normal-vision floors
+// under all-pairs comparison in both modes, which is exactly the 3-series
+// case here.
+const SERIES = [
+  { key: "signups" as const, label: "Inscrições", color: "#2a78d6" },
+  { key: "scans" as const, label: "Scans", color: "#eb6834" },
+  { key: "saves" as const, label: "Guardados", color: "#1baf7a" },
+];
+
+const WEEKDAY_LABELS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
+
+const BAR_WIDTH = 10;
+const BAR_GAP = 2;
+const GROUP_GAP = 14;
+const GROUP_WIDTH = SERIES.length * BAR_WIDTH + (SERIES.length - 1) * BAR_GAP;
+const CHART_HEIGHT = 120;
+const LABEL_HEIGHT = 20;
+const RADIUS = 3;
+
+function roundedTopBarPath(
+  x: number,
+  y: number,
+  width: number,
+  height: number
+) {
+  if (height <= 0) return null;
+  const r = Math.min(RADIUS, width / 2, height);
+  const top = y + CHART_HEIGHT - height;
+  const bottom = y + CHART_HEIGHT;
+  return `M${x},${bottom} V${top + r} Q${x},${top} ${x + r},${top} H${x + width - r} Q${x + width},${top} ${x + width},${top + r} V${bottom} Z`;
+}
+
+// A colored bar chart alone leaves the low-contrast slot (aqua "Guardados")
+// hard to read for low-vision users - this table is the "table view exists"
+// mitigation, not a decorative afterthought, and doubles as the exact
+// figures the chart deliberately doesn't label point-by-point.
+const AdminWeeklyActivityChart: React.FC<AdminWeeklyActivityChartProps> = ({
+  data,
+}) => {
+  const max = Math.max(1, ...data.flatMap((d) => SERIES.map((s) => d[s.key])));
+  const totalWidth = data.length * GROUP_WIDTH + (data.length - 1) * GROUP_GAP;
+  const totalHeight = CHART_HEIGHT + LABEL_HEIGHT;
+
+  return (
+    <div className="w-full rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-800">
+          Atividade dos últimos 7 dias
+        </h2>
+        <ul className="flex items-center gap-4 text-sm text-gray-600">
+          {SERIES.map((series) => (
+            <li key={series.key} className="flex items-center gap-1.5">
+              <span
+                className="inline-block size-2.5 rounded-full"
+                style={{ backgroundColor: series.color }}
+              />
+              {series.label}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${totalWidth} ${totalHeight}`}
+        className="h-auto w-full"
+        role="img"
+        aria-label="Gráfico de barras com inscrições, scans e estudantes guardados por dia, nos últimos 7 dias"
+      >
+        <line
+          x1={0}
+          y1={CHART_HEIGHT}
+          x2={totalWidth}
+          y2={CHART_HEIGHT}
+          stroke="#e5e7eb"
+          strokeWidth={1}
+        />
+        {data.map((day, dayIndex) => {
+          const groupX = dayIndex * (GROUP_WIDTH + GROUP_GAP);
+          const weekday = WEEKDAY_LABELS[new Date(day.date).getUTCDay()];
+          return (
+            <g key={day.date}>
+              {SERIES.map((series, seriesIndex) => {
+                const value = day[series.key];
+                const height = (value / max) * (CHART_HEIGHT - 8);
+                const x = groupX + seriesIndex * (BAR_WIDTH + BAR_GAP);
+                const path = roundedTopBarPath(x, 0, BAR_WIDTH, height);
+                return path ? (
+                  <path key={series.key} d={path} fill={series.color} />
+                ) : null;
+              })}
+              <text
+                x={groupX + GROUP_WIDTH / 2}
+                y={CHART_HEIGHT + 14}
+                textAnchor="middle"
+                className="fill-gray-500"
+                fontSize={9}
+              >
+                {weekday}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      <details className="mt-4 text-sm text-gray-600">
+        <summary className="cursor-pointer select-none">
+          Ver como tabela
+        </summary>
+        <table className="mt-2 w-full border-collapse text-left">
+          <caption className="sr-only">
+            Atividade diária dos últimos 7 dias, em números
+          </caption>
+          <thead className="text-xs tracking-wider text-gray-400 uppercase">
+            <tr>
+              <th className="py-1 pr-4">Dia</th>
+              {SERIES.map((series) => (
+                <th key={series.key} className="py-1 pr-4">
+                  {series.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((day) => (
+              <tr key={day.date} className="border-t border-gray-100">
+                <td className="py-1 pr-4">{day.date}</td>
+                {SERIES.map((series) => (
+                  <td key={series.key} className="py-1 pr-4">
+                    {day[series.key]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </details>
+    </div>
+  );
+};
+
+export default AdminWeeklyActivityChart;

--- a/src/components/AdminWeeklyActivityChart/index.tsx
+++ b/src/components/AdminWeeklyActivityChart/index.tsx
@@ -24,7 +24,10 @@ const CHART_HEIGHT = 120;
 const LABEL_HEIGHT = 20;
 const RADIUS = 3;
 
-function roundedTopBarPath(
+// Exported for its own unit test (index.test.ts) - the geometry is easy to
+// get subtly wrong (degenerate zero-height bars, radius bigger than the bar)
+// and worth a real regression guard rather than one-off manual checking.
+export function roundedTopBarPath(
   x: number,
   y: number,
   width: number,

--- a/src/components/Profile/UserButton/index.test.tsx
+++ b/src/components/Profile/UserButton/index.test.tsx
@@ -32,7 +32,7 @@ test("links a STUDENT with no profile yet back into signup", () => {
 test("links an admin to the backoffice instead of signup, even though role is null", () => {
   const user: SessionDto = { role: null, adminRole: "ADMIN", student: null };
   render(<UserButton user={user} />);
-  expect(linkHref()).toBe("/students");
+  expect(linkHref()).toBe("/overview");
 });
 
 test("links a super admin to the backoffice too", () => {
@@ -42,5 +42,5 @@ test("links a super admin to the backoffice too", () => {
     student: null,
   };
   render(<UserButton user={user} />);
-  expect(linkHref()).toBe("/students");
+  expect(linkHref()).toBe("/overview");
 });

--- a/src/components/Profile/UserButton/index.tsx
+++ b/src/components/Profile/UserButton/index.tsx
@@ -18,7 +18,7 @@ const UserButton: React.FC<UserButtonProps> = ({ user }) => {
   // isn't a STUDENT/EMPLOYEE at all) - checked first so it doesn't fall
   // into that same "unfinished student signup" branch.
   const profileUrl = user.adminRole
-    ? "/students"
+    ? "/overview"
     : user.role === "EMPLOYEE"
       ? "/dashboard"
       : user.student


### PR DESCRIPTION
## Summary

Follow-up to #270 (which itself stacks on #268/#269) — a real "backoffice template" landing page for admins, rather than dropping them on the Students list. Stacked on #270 since it's a direct continuation of the redirect-target discussion there.

- **New `/overview` page** (any admin tier, gated the same way Statistics/Students already are - the shared admin layout, no extra per-page check needed): five stat tiles (students, companies, recruiters, action completions, saved students), a weekly activity bar chart, and a merged recent-activity feed.
- **`getAdminDashboardSummary()`**: fetches the 5 counts + last-10 recent events from each of 3 sources (student signups, QR action completions, company saves) + last-7-days raw timestamps, in parallel. Merges the 3 recent-event sources into one newest-first feed (capped at 15). Buckets the 7-day window into daily counts per category in JS rather than a DB-side `date_trunc` — this is a single-event fair, not a high-volume product, so the row counts involved stay small enough that this is simpler and more portable.
- **Chart colors**: used the design system's validated categorical palette (dataviz skill) — slots 1-3 (blue/orange/aqua), the only three that clear the CVD and normal-vision floors under all-pairs comparison in both light/dark, which matches exactly this 3-series case. Ran the palette validator before using it rather than eyeballing.
- **No dark mode** on the new page — matches the rest of the admin backoffice (Sidebar, DataTable, Statistics, etc.), none of which has any dark-mode handling today. Introducing it for just this one page would be inconsistent, not more correct.
- **Chart doesn't label every bar** — that's the exact anti-pattern the dataviz skill flags. Exact figures live in a collapsible `<details><table>` instead (visible to sighted users, not just screen readers — an `sr-only` table wouldn't actually help the low-contrast-series relief requirement, since that's a low-vision concern, not a blindness one).
- **Simplification I made deliberately**: skipped a JS hover/tooltip layer on the chart (the skill's default recommendation for any chart with a plot). The collapsible table already gives exact numbers, and this is a low-traffic internal tool, not a public product — didn't think a client component + tooltip state justified itself here. Worth reconsidering if this page sees heavier real-world use than expected.
- `AdminSidebar` gets a new top-level "Dashboard" link to `/overview`, above the existing sectioned nav. `LoginPage` and `UserButton` (both from #270) now redirect admins here instead of `/students`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — new `adminDashboardService` suite (stat passthrough, feed merge/sort/cap, day-bucketing including zero-event days) + updated `LoginPage`/`UserButton` redirect assertions, all green
- [x] Verified the SVG bar-path geometry standalone (zero-height, tiny, max-height, narrow-width-radius-clamp cases) — no NaN/negative/degenerate output
- [ ] Live click-through as an admin — not done in this environment (no real Supabase session available), same limitation as the rest of this feature chain