### PR TITLE
fix: admin backoffice visual polish, login redirect, and inline schedule editing

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,13 @@ const compat = new FlatCompat({
 
 export default defineConfig([
   {
-    ignores: [".next/**", "next-env.d.ts"],
+    ignores: [
+      ".next/**",
+      "next-env.d.ts",
+      ".claude/worktrees/**",
+      "public/sw.js",
+      "public/workbox-*.js",
+    ],
   },
   {
     extends: compat.extends(

--- a/src/app/(admin)/actions/page.tsx
+++ b/src/app/(admin)/actions/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { FiEdit2 } from "react-icons/fi";
 
 import {
   parseAdminListParams,
@@ -40,7 +41,7 @@ const ActionsAdminPage = async ({ searchParams }: ActionsAdminPageProps) => {
         <h1 className="text-2xl font-bold text-gray-800">Ações</h1>
         <Link
           href="/actions/new"
-          className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
         >
           Adicionar ação
         </Link>
@@ -64,11 +65,11 @@ const ActionsAdminPage = async ({ searchParams }: ActionsAdminPageProps) => {
               aria-label={`Editar ${action.name}`}
               className="hover:text-primary"
             >
-              ✏️
+              <FiEdit2 size={16} />
             </Link>
             <Link
               href={`/actions/${action.id}`}
-              className="text-blue-500 hover:underline"
+              className="text-primary hover:underline"
             >
               QR
             </Link>

--- a/src/app/(admin)/admins/page.tsx
+++ b/src/app/(admin)/admins/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { FiEdit2 } from "react-icons/fi";
 
 import {
   parseAdminListParams,
@@ -50,7 +51,7 @@ const AdminsPage = async ({ searchParams }: AdminsPageProps) => {
         <h1 className="text-2xl font-bold text-gray-800">Admins</h1>
         <Link
           href="/admins/new"
-          className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
         >
           Adicionar admin
         </Link>
@@ -74,7 +75,7 @@ const AdminsPage = async ({ searchParams }: AdminsPageProps) => {
               aria-label={`Editar ${admin.name}`}
               className="hover:text-primary"
             >
-              ✏️
+              <FiEdit2 size={16} />
             </Link>
             <AdminToggleButton
               checked={admin.active}

--- a/src/app/(admin)/companies/page.tsx
+++ b/src/app/(admin)/companies/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { FiEdit2 } from "react-icons/fi";
 
 import {
   parseAdminListParams,
@@ -65,7 +66,7 @@ const CompaniesAdminPage = async ({
           </Link>
           <Link
             href="/companies/new"
-            className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+            className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
           >
             Adicionar empresa
           </Link>
@@ -90,7 +91,7 @@ const CompaniesAdminPage = async ({
               aria-label={`Editar ${company.name}`}
               className="hover:text-primary"
             >
-              ✏️
+              <FiEdit2 size={16} />
             </Link>
             <AdminToggleButton
               checked={company.active}

--- a/src/app/(admin)/employees/page.tsx
+++ b/src/app/(admin)/employees/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { FiEdit2 } from "react-icons/fi";
 
 import {
   parseAdminListParams,
@@ -43,7 +44,7 @@ const EmployeesAdminPage = async ({
         <h1 className="text-2xl font-bold text-gray-800">Recrutadores</h1>
         <Link
           href="/employees/new"
-          className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
         >
           Adicionar recrutador
         </Link>
@@ -67,7 +68,7 @@ const EmployeesAdminPage = async ({
               aria-label={`Editar ${employee.name}`}
               className="hover:text-primary"
             >
-              ✏️
+              <FiEdit2 size={16} />
             </Link>
             <AdminToggleButton
               checked={employee.active}

--- a/src/app/(admin)/faqs/page.tsx
+++ b/src/app/(admin)/faqs/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { FiEdit2 } from "react-icons/fi";
 
 import {
   parseAdminListParams,
@@ -51,7 +52,7 @@ const FaqsAdminPage = async ({ searchParams }: FaqsAdminPageProps) => {
           </Link>
           <Link
             href="/faqs/new"
-            className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+            className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
           >
             Adicionar pergunta
           </Link>
@@ -76,7 +77,7 @@ const FaqsAdminPage = async ({ searchParams }: FaqsAdminPageProps) => {
               aria-label={`Editar ${faq.question}`}
               className="hover:text-primary"
             >
-              ✏️
+              <FiEdit2 size={16} />
             </Link>
             <AdminDeleteButton
               deleteUrl={`/admin/faqs/${faq.id}`}

--- a/src/app/(admin)/interests/page.tsx
+++ b/src/app/(admin)/interests/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { FiEdit2 } from "react-icons/fi";
 
 import {
   parseAdminListParams,
@@ -46,7 +47,7 @@ const InterestsAdminPage = async ({
         <h1 className="text-2xl font-bold text-gray-800">Interesses</h1>
         <Link
           href="/interests/new"
-          className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
         >
           Adicionar interesse
         </Link>
@@ -70,7 +71,7 @@ const InterestsAdminPage = async ({
               aria-label={`Editar ${interest.name}`}
               className="hover:text-primary"
             >
-              ✏️
+              <FiEdit2 size={16} />
             </Link>
             <AdminDeleteButton
               deleteUrl={`/admin/interests/${interest.id}`}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -19,7 +19,7 @@ export default async function AdminLayout({
 
   return (
     <SessionAuthLayout>
-      <Topbar />
+      <Topbar light />
       <div className="flex min-h-screen pt-16">
         <AdminSidebar isSuperAdmin={session.adminRole === "SUPER_ADMIN"} />
         <main id="main-content" className="min-w-0 flex-1">

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -19,7 +19,7 @@ export default async function AdminLayout({
 
   return (
     <SessionAuthLayout>
-      <Topbar light />
+      <Topbar solid />
       <div className="flex min-h-screen pt-16">
         <AdminSidebar isSuperAdmin={session.adminRole === "SUPER_ADMIN"} />
         <main id="main-content" className="min-w-0 flex-1">

--- a/src/app/(admin)/schedule/page.tsx
+++ b/src/app/(admin)/schedule/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { FiEdit2 } from "react-icons/fi";
 
 import {
   parseAdminListParams,
@@ -58,7 +59,7 @@ const ScheduleAdminPage = async ({ searchParams }: ScheduleAdminPageProps) => {
           </Link>
           <Link
             href="/schedule/new"
-            className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+            className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
           >
             Adicionar atividade
           </Link>
@@ -83,7 +84,7 @@ const ScheduleAdminPage = async ({ searchParams }: ScheduleAdminPageProps) => {
               aria-label={`Editar ${event.activity}`}
               className="hover:text-primary"
             >
-              ✏️
+              <FiEdit2 size={16} />
             </Link>
             <AdminDeleteButton
               deleteUrl={`/admin/schedule/${event.id}`}

--- a/src/app/(admin)/sponsors/page.tsx
+++ b/src/app/(admin)/sponsors/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { FiEdit2 } from "react-icons/fi";
 
 import {
   parseAdminListParams,
@@ -54,7 +55,7 @@ const SponsorsAdminPage = async ({ searchParams }: SponsorsAdminPageProps) => {
         <h1 className="text-2xl font-bold text-gray-800">Patrocinadores</h1>
         <Link
           href="/sponsors/new"
-          className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
         >
           Adicionar patrocinador
         </Link>
@@ -78,7 +79,7 @@ const SponsorsAdminPage = async ({ searchParams }: SponsorsAdminPageProps) => {
               aria-label={`Editar ${sponsor.name}`}
               className="hover:text-primary"
             >
-              ✏️
+              <FiEdit2 size={16} />
             </Link>
             <AdminToggleButton
               checked={sponsor.active}

--- a/src/app/(admin)/storage/cvs/page.tsx
+++ b/src/app/(admin)/storage/cvs/page.tsx
@@ -38,7 +38,7 @@ const columns: DataTableColumn<StorageRow>[] = [
         href={file.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-blue-500 hover:underline"
+        className="text-primary hover:underline"
       >
         Abrir
       </a>

--- a/src/app/(admin)/storage/page.tsx
+++ b/src/app/(admin)/storage/page.tsx
@@ -52,7 +52,7 @@ const columns: DataTableColumn<StorageRow>[] = [
         href={file.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-blue-500 hover:underline"
+        className="text-primary hover:underline"
       >
         Abrir
       </a>

--- a/src/app/(admin)/students/page.tsx
+++ b/src/app/(admin)/students/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { FiEdit2 } from "react-icons/fi";
 
 import {
   parseAdminListParams,
@@ -42,7 +43,7 @@ const StudentsAdminPage = async ({ searchParams }: StudentsAdminPageProps) => {
         <h1 className="text-2xl font-bold text-gray-800">Estudantes</h1>
         <Link
           href="/students/new"
-          className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
         >
           Adicionar estudante
         </Link>
@@ -66,7 +67,7 @@ const StudentsAdminPage = async ({ searchParams }: StudentsAdminPageProps) => {
               aria-label={`Editar ${student.name}`}
               className="hover:text-primary"
             >
-              ✏️
+              <FiEdit2 size={16} />
             </Link>
             <AdminToggleButton
               checked={student.active}

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -3,13 +3,13 @@ import { beforeEach, expect, test, vi } from "vitest";
 
 import LoginPage from "./page";
 
-const { pushMock, refreshMock, logInMock, fetchSessionMock, sessionUserMock } =
+const { pushMock, refreshMock, logInMock, fetchSessionMock, getSessionMock } =
   vi.hoisted(() => ({
     pushMock: vi.fn(),
     refreshMock: vi.fn(),
     logInMock: vi.fn(),
     fetchSessionMock: vi.fn(),
-    sessionUserMock: vi.fn(),
+    getSessionMock: vi.fn(),
   }));
 
 vi.mock("next/navigation", () => ({
@@ -18,12 +18,22 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/client/api/auth", () => ({
   logIn: (...args: unknown[]) => logInMock(...args),
 }));
+// The AuthContext's `user` is always null here, on purpose: it stays stale
+// until React's *next* render, exactly like the real AuthContextProvider
+// (setUser from fetchSession() doesn't take effect synchronously). If
+// LoginPage ever goes back to reading session.user for the redirect
+// instead of calling getSession() directly, every test below would see a
+// null user and wrongly redirect to "/" - that's the regression this file
+// guards against, not just "does the right URL get picked".
 vi.mock("@/hooks/useSession", () => ({
   default: () => ({
-    user: sessionUserMock(),
+    user: null,
     fetchSession: fetchSessionMock,
     clear: vi.fn(),
   }),
+}));
+vi.mock("@/client/api/session", () => ({
+  default: () => getSessionMock(),
 }));
 vi.mock("@/components/AuthNeiButton", () => ({
   default: () => <button>Continuar com AuthNEI</button>,
@@ -45,7 +55,7 @@ const submitLogin = () => {
 };
 
 test("sends an EMPLOYEE to the dashboard", async () => {
-  sessionUserMock.mockReturnValue({
+  getSessionMock.mockResolvedValue({
     role: "EMPLOYEE",
     adminRole: null,
     student: null,
@@ -58,7 +68,7 @@ test("sends an EMPLOYEE to the dashboard", async () => {
 });
 
 test("sends a STUDENT with a profile to their student page", async () => {
-  sessionUserMock.mockReturnValue({
+  getSessionMock.mockResolvedValue({
     role: "STUDENT",
     adminRole: null,
     student: { code: "s1", name: "Jane" },
@@ -71,7 +81,7 @@ test("sends a STUDENT with a profile to their student page", async () => {
 });
 
 test("sends a STUDENT with no profile yet back into signup instead of the homepage", async () => {
-  sessionUserMock.mockReturnValue({
+  getSessionMock.mockResolvedValue({
     role: "STUDENT",
     adminRole: null,
     student: null,
@@ -84,7 +94,7 @@ test("sends a STUDENT with no profile yet back into signup instead of the homepa
 });
 
 test("sends an admin to the backoffice instead of the homepage, even though role is null", async () => {
-  sessionUserMock.mockReturnValue({
+  getSessionMock.mockResolvedValue({
     role: null,
     adminRole: "ADMIN",
     student: null,
@@ -97,7 +107,7 @@ test("sends an admin to the backoffice instead of the homepage, even though role
 });
 
 test("sends a super admin to the backoffice too", async () => {
-  sessionUserMock.mockReturnValue({
+  getSessionMock.mockResolvedValue({
     role: null,
     adminRole: "SUPER_ADMIN",
     student: null,
@@ -110,7 +120,7 @@ test("sends a super admin to the backoffice too", async () => {
 });
 
 test("falls back to the homepage for a session with no role and no admin tier", async () => {
-  sessionUserMock.mockReturnValue({
+  getSessionMock.mockResolvedValue({
     role: null,
     adminRole: null,
     student: null,
@@ -122,9 +132,21 @@ test("falls back to the homepage for a session with no role and no admin tier", 
   await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/"));
 });
 
+test("still calls fetchSession so the rest of the UI (e.g. TopBar) picks up the new session", async () => {
+  getSessionMock.mockResolvedValue({
+    role: "EMPLOYEE",
+    adminRole: null,
+    student: null,
+  });
+
+  render(<LoginPage />);
+  submitLogin();
+
+  await waitFor(() => expect(fetchSessionMock).toHaveBeenCalled());
+});
+
 test("shows a generic error and doesn't redirect when login fails", async () => {
   logInMock.mockResolvedValue(false);
-  sessionUserMock.mockReturnValue(null);
 
   render(<LoginPage />);
   submitLogin();

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -132,17 +132,15 @@ test("falls back to the homepage for a session with no role and no admin tier", 
   await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/"));
 });
 
-test("still calls fetchSession so the rest of the UI (e.g. TopBar) picks up the new session", async () => {
-  getSessionMock.mockResolvedValue({
-    role: "EMPLOYEE",
-    adminRole: null,
-    student: null,
-  });
+test("still updates the context (e.g. so TopBar picks up the new session) with the same fetched user, not a second request", async () => {
+  const freshUser = { role: "EMPLOYEE", adminRole: null, student: null };
+  getSessionMock.mockResolvedValue(freshUser);
 
   render(<LoginPage />);
   submitLogin();
 
-  await waitFor(() => expect(fetchSessionMock).toHaveBeenCalled());
+  await waitFor(() => expect(fetchSessionMock).toHaveBeenCalledWith(freshUser));
+  expect(getSessionMock).toHaveBeenCalledTimes(1);
 });
 
 test("shows a generic error and doesn't redirect when login fails", async () => {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -10,6 +10,7 @@ import Input from "@/components/ui/Input";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import AuthNeiButton from "@/components/AuthNeiButton";
 import { logIn } from "@/client/api/auth";
+import getSession from "@/client/api/session";
 
 const LoginPage: React.FC = () => {
   const session = useSession();
@@ -46,7 +47,14 @@ const LoginPage: React.FC = () => {
     const password = passwordRef.current?.value as string;
 
     if (await logIn(email, password)) {
-      await session.fetchSession();
+      // session.user (from the AuthContext) is stale here - fetchSession()
+      // updates it via setState, which only takes effect on React's *next*
+      // render, not synchronously in this same closure. Fetching directly
+      // gets the just-established session's real data for this redirect
+      // decision; fetchSession() still runs (fire-and-forget) so the rest
+      // of the UI - e.g. TopBar - picks up the new session too.
+      session.fetchSession();
+      const freshUser = await getSession();
 
       // Redirect based on user role. Checked before role, since an admin
       // account has role: null (it isn't a STUDENT/EMPLOYEE at all) and
@@ -55,15 +63,13 @@ const LoginPage: React.FC = () => {
       // established the account but the signup wizard was abandoned before
       // it finished - so send them back into the wizard to complete it
       // instead of the homepage.
-      if (session.user?.adminRole) {
+      if (freshUser?.adminRole) {
         router.push("/overview");
-      } else if (session.user?.role === "EMPLOYEE") {
+      } else if (freshUser?.role === "EMPLOYEE") {
         router.push("/dashboard");
-      } else if (session.user?.role === "STUDENT") {
+      } else if (freshUser?.role === "STUDENT") {
         router.push(
-          session.user.student
-            ? `/student/${session.user.student.code}`
-            : "/signup"
+          freshUser.student ? `/student/${freshUser.student.code}` : "/signup"
         );
       } else {
         router.push("/");

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -51,10 +51,11 @@ const LoginPage: React.FC = () => {
       // updates it via setState, which only takes effect on React's *next*
       // render, not synchronously in this same closure. Fetching directly
       // gets the just-established session's real data for this redirect
-      // decision; fetchSession() still runs (fire-and-forget) so the rest
-      // of the UI - e.g. TopBar - picks up the new session too.
-      session.fetchSession();
+      // decision, then hands that same value to fetchSession() so the rest
+      // of the UI - e.g. TopBar - picks up the new session too, without a
+      // second, redundant request for data already in hand.
       const freshUser = await getSession();
+      session.fetchSession(freshUser);
 
       // Redirect based on user role. Checked before role, since an admin
       // account has role: null (it isn't a STUDENT/EMPLOYEE at all) and

--- a/src/app/api/admin/schedule/order/route.test.ts
+++ b/src/app/api/admin/schedule/order/route.test.ts
@@ -82,6 +82,63 @@ test("PATCH rejects a malformed body with 400, without persisting anything", asy
   assert.equal(vi.mocked(updateScheduleOrder).mock.calls.length, 0);
 });
 
+test("PATCH rejects a malformed time string with 400, without persisting anything", async () => {
+  const getServerSession = (
+    await import("@/application/services/sessionService")
+  ).default;
+  vi.mocked(getServerSession).mockResolvedValue(adminSession as never);
+
+  const { updateScheduleOrder } =
+    await import("@/application/services/scheduleService");
+
+  const { PATCH } = await import("./route");
+  const res = await PATCH(
+    patchRequest({
+      updates: [
+        {
+          id: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          day: 1,
+          order: 0,
+          startTime: "9am",
+        },
+      ],
+    }),
+    { params: Promise.resolve({}) }
+  );
+
+  assert.equal(res.status, 400);
+  assert.equal(vi.mocked(updateScheduleOrder).mock.calls.length, 0);
+});
+
+test("PATCH commits a submitted startTime/endTime alongside the reorder", async () => {
+  const getServerSession = (
+    await import("@/application/services/sessionService")
+  ).default;
+  vi.mocked(getServerSession).mockResolvedValue(adminSession as never);
+
+  const { updateScheduleOrder } =
+    await import("@/application/services/scheduleService");
+  vi.mocked(updateScheduleOrder).mockResolvedValue(undefined);
+
+  const updates = [
+    {
+      id: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      day: 1,
+      order: 0,
+      startTime: "09:00",
+      endTime: "09:30",
+    },
+  ];
+
+  const { PATCH } = await import("./route");
+  const res = await PATCH(patchRequest({ updates }), {
+    params: Promise.resolve({}),
+  });
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(vi.mocked(updateScheduleOrder).mock.calls[0]?.[0], updates);
+});
+
 test("PATCH commits the reorder for a valid admin request", async () => {
   const getServerSession = (
     await import("@/application/services/sessionService")

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,10 +10,13 @@
   /* Colors (migrated from your old config) */
   --color-text: #ffffff;
   --color-background: #141414;
-  --color-primary: rgba(255, 255, 255, 0.7);
-  /* backward-compatible aliases for older variable names used across the codebase */
-  /* Restore legacy button primary color (orange) that was used before the reset */
-  --primary: #f97316; /* Tailwind orange-500, matches previous orange-ish look */
+  --color-primary: #f97316; /* Tailwind orange-500, the site's brand orange */
+  /* backward-compatible alias for older code (e.g. .auth-pane below) that
+     uses var(--primary) directly instead of a bg-primary/text-primary
+     utility - only --color-* keys become Tailwind utilities in v4, so this
+     must stay a plain alias of --color-primary, not a second independent
+     value, or the two silently drift apart again. */
+  --primary: var(--color-primary);
   --color-secondary: #484848;
   /* legacy alias for older code that used --secondary */
   --secondary: var(--color-secondary);

--- a/src/application/repositories/scheduleRepository.ts
+++ b/src/application/repositories/scheduleRepository.ts
@@ -92,19 +92,31 @@ export const deleteScheduleEvent = (id: string) =>
 // transaction; a passed-in transaction client doesn't expose `$transaction`
 // itself, so updates run sequentially against it instead.
 export const bulkUpdateScheduleOrder = async (
-  updates: { id: string; day: number; order: number }[],
+  updates: {
+    id: string;
+    day: number;
+    order: number;
+    startTime?: string;
+    endTime?: string;
+  }[],
   db: DbClient = prisma
 ) => {
   if (db === prisma) {
     await prisma.$transaction(
-      updates.map(({ id, day, order }) =>
-        prisma.scheduleEvent.update({ where: { id }, data: { day, order } })
+      updates.map(({ id, day, order, startTime, endTime }) =>
+        prisma.scheduleEvent.update({
+          where: { id },
+          data: { day, order, startTime, endTime },
+        })
       )
     );
     return;
   }
 
-  for (const { id, day, order } of updates) {
-    await db.scheduleEvent.update({ where: { id }, data: { day, order } });
+  for (const { id, day, order, startTime, endTime } of updates) {
+    await db.scheduleEvent.update({
+      where: { id },
+      data: { day, order, startTime, endTime },
+    });
   }
 };

--- a/src/application/services/scheduleService.test.ts
+++ b/src/application/services/scheduleService.test.ts
@@ -108,6 +108,34 @@ test("rejects a partial reorder that would collide with an untouched row in the 
   expect(bulkUpdateScheduleOrder).not.toHaveBeenCalled();
 });
 
+test("persists a submitted startTime/endTime alongside the reorder", async () => {
+  await updateScheduleOrder([
+    { id: "a", day: 1, order: 0, startTime: "08:00", endTime: "08:30" },
+    { id: "b", day: 1, order: 1 },
+  ]);
+
+  expect(bulkUpdateScheduleOrder).toHaveBeenCalledWith(
+    [
+      { id: "a", day: 1, order: 0, startTime: "08:00", endTime: "08:30" },
+      { id: "b", day: 1, order: 1 },
+    ],
+    transaction
+  );
+});
+
+test("validates a submitted time edit against the rest of its day, not just the reorder", async () => {
+  // a's submitted endTime (10:30) would overlap b's existing 10:00-11:00 -
+  // must be caught even though only the order/time changed, not the day.
+  await expect(
+    updateScheduleOrder([
+      { id: "a", day: 1, order: 0, endTime: "10:30" },
+      { id: "b", day: 1, order: 1 },
+    ])
+  ).rejects.toThrow("Schedule order is not chronologically valid");
+
+  expect(bulkUpdateScheduleOrder).not.toHaveBeenCalled();
+});
+
 test("throws Not found if an update references an id that no longer exists", async () => {
   await expect(
     updateScheduleOrder([{ id: "missing", day: 1, order: 0 }])

--- a/src/application/services/scheduleService.ts
+++ b/src/application/services/scheduleService.ts
@@ -194,7 +194,13 @@ export async function deleteScheduleEventForAdmin(id: string) {
 // here against each row's actual startTime/endTime before committing,
 // same rule (domain/schedule/scheduleValidation.ts) the board uses.
 export async function updateScheduleOrder(
-  updates: { id: string; day: number; order: number }[]
+  updates: {
+    id: string;
+    day: number;
+    order: number;
+    startTime?: string;
+    endTime?: string;
+  }[]
 ) {
   if (updates.length === 0) return;
 
@@ -220,13 +226,10 @@ export async function updateScheduleOrder(
       const update = updateById.get(event.id);
       const day = update?.day ?? event.day;
       const order = update?.order ?? event.order;
+      const startTime = update?.startTime ?? event.startTime;
+      const endTime = update?.endTime ?? event.endTime;
       const rows = byDay.get(day) ?? [];
-      rows.push({
-        id: event.id,
-        startTime: event.startTime,
-        endTime: event.endTime,
-        order,
-      });
+      rows.push({ id: event.id, startTime, endTime, order });
       byDay.set(day, rows);
     }
 

--- a/src/components/AdminActivityFeed/index.tsx
+++ b/src/components/AdminActivityFeed/index.tsx
@@ -1,3 +1,5 @@
+import { FiBookmark, FiCamera, FiUserPlus } from "react-icons/fi";
+
 import type { ActivityEvent } from "@/application/services/adminDashboardService";
 
 interface AdminActivityFeedProps {
@@ -9,11 +11,11 @@ interface AdminActivityFeedProps {
 // noise on a list, unlike the chart).
 const TYPE_STYLE: Record<
   ActivityEvent["type"],
-  { color: string; icon: string }
+  { color: string; icon: React.ComponentType<{ size?: number }> }
 > = {
-  signup: { color: "#2a78d6", icon: "👤" },
-  scan: { color: "#eb6834", icon: "📷" },
-  save: { color: "#1baf7a", icon: "⭐" },
+  signup: { color: "#2a78d6", icon: FiUserPlus },
+  scan: { color: "#eb6834", icon: FiCamera },
+  save: { color: "#1baf7a", icon: FiBookmark },
 };
 
 function formatRelativeTime(iso: string) {
@@ -37,24 +39,27 @@ const AdminActivityFeed: React.FC<AdminActivityFeedProps> = ({ events }) => (
       <p className="text-gray-500">Ainda não há atividade.</p>
     ) : (
       <ul className="flex flex-col gap-3">
-        {events.map((event, index) => (
-          <li
-            key={`${event.type}-${event.timestamp}-${index}`}
-            className="flex items-start gap-3 text-sm"
-          >
-            <span
-              className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full text-xs"
-              style={{ backgroundColor: `${TYPE_STYLE[event.type].color}1a` }}
-              aria-hidden="true"
+        {events.map((event, index) => {
+          const { color, icon: Icon } = TYPE_STYLE[event.type];
+          return (
+            <li
+              key={`${event.type}-${event.timestamp}-${index}`}
+              className="flex items-start gap-3 text-sm"
             >
-              {TYPE_STYLE[event.type].icon}
-            </span>
-            <span className="flex-1 text-gray-700">{event.label}</span>
-            <span className="shrink-0 text-gray-400">
-              {formatRelativeTime(event.timestamp)}
-            </span>
-          </li>
-        ))}
+              <span
+                className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full"
+                style={{ backgroundColor: `${color}1a`, color }}
+                aria-hidden="true"
+              >
+                <Icon size={13} />
+              </span>
+              <span className="flex-1 text-gray-700">{event.label}</span>
+              <span className="shrink-0 text-gray-400">
+                {formatRelativeTime(event.timestamp)}
+              </span>
+            </li>
+          );
+        })}
       </ul>
     )}
   </div>

--- a/src/components/AdminDeleteButton/index.tsx
+++ b/src/components/AdminDeleteButton/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { FiTrash2 } from "react-icons/fi";
 import { toast } from "react-toastify";
 
 import { httpClient } from "@/lib/http/client";
@@ -45,9 +46,9 @@ const AdminDeleteButton: React.FC<AdminDeleteButtonProps> = ({
         disabled={disabled}
         aria-label={`Eliminar ${itemLabel}`}
         title={disabled ? disabledReason : undefined}
-        className="text-red-500 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-30"
+        className="flex items-center text-red-500 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-30"
       >
-        🗑
+        <FiTrash2 size={16} />
       </button>
       <ConfirmDialog
         isVisible={isVisible}

--- a/src/components/AdminForm/index.tsx
+++ b/src/components/AdminForm/index.tsx
@@ -68,7 +68,9 @@ export interface AdminFormPasswordSection {
 }
 
 export type AdminFormSection =
-  AdminFormFieldsSection | AdminFormImageSection | AdminFormPasswordSection;
+  | AdminFormFieldsSection
+  | AdminFormImageSection
+  | AdminFormPasswordSection;
 
 interface AdminFormProps {
   /** Present -> editing an existing record; absent -> creating a new one. */
@@ -360,7 +362,7 @@ const AdminForm: React.FC<AdminFormProps> = ({
       <button
         type="submit"
         disabled={isPending}
-        className="rounded-md bg-blue-500 p-2 text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+        className="rounded-md bg-primary p-2 text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {isPending
           ? "A guardar..."

--- a/src/components/AdminSavedSection/index.tsx
+++ b/src/components/AdminSavedSection/index.tsx
@@ -71,7 +71,7 @@ const AdminSavedSection: React.FC<AdminSavedSectionProps> = ({ companies }) => {
         <button
           type="submit"
           disabled={isPending}
-          className="rounded-md bg-blue-500 p-2 text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md bg-primary p-2 text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isPending ? "A guardar..." : "Save Student"}
         </button>

--- a/src/components/AdminWeeklyActivityChart/index.tsx
+++ b/src/components/AdminWeeklyActivityChart/index.tsx
@@ -48,7 +48,13 @@ const AdminWeeklyActivityChart: React.FC<AdminWeeklyActivityChartProps> = ({
   data,
 }) => {
   const max = Math.max(1, ...data.flatMap((d) => SERIES.map((s) => d[s.key])));
-  const totalWidth = data.length * GROUP_WIDTH + (data.length - 1) * GROUP_GAP;
+  // data.length - 1 goes negative for an empty array, producing an invalid
+  // (negative-width) viewBox - Math.max(1, ...) keeps the SVG well-formed
+  // even with no data, rather than rendering unpredictably.
+  const totalWidth = Math.max(
+    1,
+    data.length * GROUP_WIDTH + (data.length - 1) * GROUP_GAP
+  );
   const totalHeight = CHART_HEIGHT + LABEL_HEIGHT;
 
   return (
@@ -72,6 +78,16 @@ const AdminWeeklyActivityChart: React.FC<AdminWeeklyActivityChartProps> = ({
 
       <svg
         viewBox={`0 0 ${totalWidth} ${totalHeight}`}
+        // Explicit intrinsic width/height (not just viewBox) is what lets
+        // the browser derive the aspect ratio for "w-full h-auto" sizing -
+        // without them, browsers fall back to inconsistent default sizing
+        // for a percentage-width/auto-height SVG, which is what was
+        // stretching this chart to the wrong scale. The inline aspectRatio
+        // is a second, CSS-only safeguard that doesn't depend on that
+        // inference at all.
+        width={totalWidth}
+        height={totalHeight}
+        style={{ aspectRatio: `${totalWidth} / ${totalHeight}` }}
         className="h-auto w-full"
         role="img"
         aria-label="Gráfico de barras com inscrições, scans e estudantes guardados por dia, nos últimos 7 dias"

--- a/src/components/CompanyTierBoard/index.tsx
+++ b/src/components/CompanyTierBoard/index.tsx
@@ -234,7 +234,7 @@ const CompanyTierBoard: React.FC<CompanyTierBoardProps> = ({ companies }) => {
         type="button"
         onClick={handleSave}
         disabled={isSaving}
-        className="w-fit self-end rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+        className="w-fit self-end rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {isSaving ? "A guardar..." : "Guardar"}
       </button>

--- a/src/components/FaqBoard/index.tsx
+++ b/src/components/FaqBoard/index.tsx
@@ -86,7 +86,7 @@ const FaqBoard: React.FC<FaqBoardProps> = ({ faqs }) => {
         type="button"
         onClick={handleSave}
         disabled={isSaving}
-        className="w-fit self-end rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+        className="w-fit self-end rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {isSaving ? "A guardar..." : "Guardar"}
       </button>

--- a/src/components/LogoutButton/index.tsx
+++ b/src/components/LogoutButton/index.tsx
@@ -4,13 +4,7 @@ import { BiLogOut } from "react-icons/bi";
 
 import { useLogout } from "@/hooks/useLogout";
 
-interface LogoutButtonProps {
-  // See UserButton's `light` prop - same reasoning (TopBar's icons default
-  // to white, invisible on the admin backoffice's light background).
-  light?: boolean;
-}
-
-const LogoutButton: React.FC<LogoutButtonProps> = ({ light = false }) => {
+const LogoutButton: React.FC = () => {
   const { handleLogout, ConfirmDialog } = useLogout();
 
   return (
@@ -18,7 +12,7 @@ const LogoutButton: React.FC<LogoutButtonProps> = ({ light = false }) => {
       <button
         onClick={handleLogout}
         aria-label="Terminar sessão"
-        className={`flex size-full items-center justify-center text-xl transition-colors hover:text-primary ${light ? "fill-gray-700" : "fill-white"}`}
+        className="flex size-full items-center justify-center fill-white text-xl transition-colors hover:text-primary"
       >
         <BiLogOut />
       </button>

--- a/src/components/LogoutButton/index.tsx
+++ b/src/components/LogoutButton/index.tsx
@@ -4,7 +4,13 @@ import { BiLogOut } from "react-icons/bi";
 
 import { useLogout } from "@/hooks/useLogout";
 
-const LogoutButton: React.FC = () => {
+interface LogoutButtonProps {
+  // See UserButton's `light` prop - same reasoning (TopBar's icons default
+  // to white, invisible on the admin backoffice's light background).
+  light?: boolean;
+}
+
+const LogoutButton: React.FC<LogoutButtonProps> = ({ light = false }) => {
   const { handleLogout, ConfirmDialog } = useLogout();
 
   return (
@@ -12,7 +18,7 @@ const LogoutButton: React.FC = () => {
       <button
         onClick={handleLogout}
         aria-label="Terminar sessão"
-        className="flex size-full items-center justify-center fill-white text-xl transition-colors hover:text-primary"
+        className={`flex size-full items-center justify-center text-xl transition-colors hover:text-primary ${light ? "fill-gray-700" : "fill-white"}`}
       >
         <BiLogOut />
       </button>

--- a/src/components/Profile/UserButton/index.test.tsx
+++ b/src/components/Profile/UserButton/index.test.tsx
@@ -45,16 +45,18 @@ test("links a super admin to the backoffice too", () => {
   expect(linkHref()).toBe("/overview");
 });
 
-test("defaults to a white icon, for TopBar's usual dark background", () => {
-  const user: SessionDto = { role: "EMPLOYEE", adminRole: null, student: null };
+test("shows a distinct admin icon instead of the generic profile icon", () => {
+  const user: SessionDto = { role: null, adminRole: "ADMIN", student: null };
   render(<UserButton user={user} />);
-  expect(screen.getByRole("link").className).toContain("fill-white");
+  expect(
+    screen.getByRole("link", { name: "Área de administração" })
+  ).toBeInTheDocument();
 });
 
-test("uses a dark icon in light mode, for the admin backoffice's light background", () => {
-  const user: SessionDto = { role: null, adminRole: "ADMIN", student: null };
-  render(<UserButton user={user} light />);
-  const className = screen.getByRole("link").className;
-  expect(className).toContain("fill-gray-700");
-  expect(className).not.toContain("fill-white");
+test("shows the generic profile icon for non-admins", () => {
+  const user: SessionDto = { role: "EMPLOYEE", adminRole: null, student: null };
+  render(<UserButton user={user} />);
+  expect(
+    screen.getByRole("link", { name: "O meu perfil" })
+  ).toBeInTheDocument();
 });

--- a/src/components/Profile/UserButton/index.test.tsx
+++ b/src/components/Profile/UserButton/index.test.tsx
@@ -44,3 +44,17 @@ test("links a super admin to the backoffice too", () => {
   render(<UserButton user={user} />);
   expect(linkHref()).toBe("/overview");
 });
+
+test("defaults to a white icon, for TopBar's usual dark background", () => {
+  const user: SessionDto = { role: "EMPLOYEE", adminRole: null, student: null };
+  render(<UserButton user={user} />);
+  expect(screen.getByRole("link").className).toContain("fill-white");
+});
+
+test("uses a dark icon in light mode, for the admin backoffice's light background", () => {
+  const user: SessionDto = { role: null, adminRole: "ADMIN", student: null };
+  render(<UserButton user={user} light />);
+  const className = screen.getByRole("link").className;
+  expect(className).toContain("fill-gray-700");
+  expect(className).not.toContain("fill-white");
+});

--- a/src/components/Profile/UserButton/index.tsx
+++ b/src/components/Profile/UserButton/index.tsx
@@ -2,18 +2,15 @@
 
 import Link from "next/link";
 import { LiaUser } from "react-icons/lia";
+import { MdOutlineAdminPanelSettings } from "react-icons/md";
 
 import type { SessionDto } from "@/application/dto/sessionDto";
 
 interface UserButtonProps {
   user: SessionDto;
-  // TopBar renders white icons by default (its background is dark
-  // everywhere except the admin backoffice, which is a light page from the
-  // top - a white icon there is invisible, not just low-contrast).
-  light?: boolean;
 }
 
-const UserButton: React.FC<UserButtonProps> = ({ user, light = false }) => {
+const UserButton: React.FC<UserButtonProps> = ({ user }) => {
   // A STUDENT-role session can exist with no Student row yet - e.g. AuthNEI
   // established the account but the signup wizard was abandoned or
   // interrupted before the profile step. Route back into the wizard to
@@ -32,9 +29,13 @@ const UserButton: React.FC<UserButtonProps> = ({ user, light = false }) => {
   return (
     <Link
       href={profileUrl}
-      className={`z-20 flex size-full items-center justify-center text-2xl transition-colors hover:text-primary ${light ? "fill-gray-700" : "fill-white"}`}
+      aria-label={user.adminRole ? "Área de administração" : "O meu perfil"}
+      className="z-20 flex size-full items-center justify-center fill-white text-2xl transition-colors hover:text-primary"
     >
-      <LiaUser />
+      {/* A distinct icon for admins - this doesn't lead to a personal
+          profile like it does for everyone else, it opens the admin
+          section, so it shouldn't look like a "your profile" link. */}
+      {user.adminRole ? <MdOutlineAdminPanelSettings /> : <LiaUser />}
     </Link>
   );
 };

--- a/src/components/Profile/UserButton/index.tsx
+++ b/src/components/Profile/UserButton/index.tsx
@@ -7,9 +7,13 @@ import type { SessionDto } from "@/application/dto/sessionDto";
 
 interface UserButtonProps {
   user: SessionDto;
+  // TopBar renders white icons by default (its background is dark
+  // everywhere except the admin backoffice, which is a light page from the
+  // top - a white icon there is invisible, not just low-contrast).
+  light?: boolean;
 }
 
-const UserButton: React.FC<UserButtonProps> = ({ user }) => {
+const UserButton: React.FC<UserButtonProps> = ({ user, light = false }) => {
   // A STUDENT-role session can exist with no Student row yet - e.g. AuthNEI
   // established the account but the signup wizard was abandoned or
   // interrupted before the profile step. Route back into the wizard to
@@ -28,7 +32,7 @@ const UserButton: React.FC<UserButtonProps> = ({ user }) => {
   return (
     <Link
       href={profileUrl}
-      className="z-20 flex size-full items-center justify-center fill-white text-2xl transition-colors hover:text-primary"
+      className={`z-20 flex size-full items-center justify-center text-2xl transition-colors hover:text-primary ${light ? "fill-gray-700" : "fill-white"}`}
     >
       <LiaUser />
     </Link>

--- a/src/components/ScheduleBoard/index.test.tsx
+++ b/src/components/ScheduleBoard/index.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import ScheduleBoard from ".";
+
+const { refreshMock, patchMock, toastSuccessMock, toastErrorMock } = vi.hoisted(
+  () => ({
+    refreshMock: vi.fn(),
+    patchMock: vi.fn(),
+    toastSuccessMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+  })
+);
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: refreshMock }),
+}));
+vi.mock("react-toastify", () => ({
+  toast: { success: toastSuccessMock, error: toastErrorMock },
+}));
+vi.mock("@/lib/http/client", () => ({
+  httpClient: { patch: (...args: unknown[]) => patchMock(...args) },
+}));
+
+const events = [
+  { id: "a", day: 1, startTime: "09:00", endTime: "10:00", activity: "Talk A" },
+  { id: "b", day: 1, startTime: "10:00", endTime: "11:00", activity: "Talk B" },
+];
+
+const timeInputs = () =>
+  screen.getAllByDisplayValue(/^\d\d:\d\d$/) as HTMLInputElement[];
+
+const saveButton = () => screen.getByRole("button", { name: /Guardar/ });
+
+const invalidWarning = () =>
+  screen.queryByText("Alguns horários ficam sobrepostos com esta ordem.");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("save is enabled and no warning is shown for a chronologically valid board", () => {
+  render(<ScheduleBoard events={events} />);
+
+  expect(invalidWarning()).not.toBeInTheDocument();
+  expect(saveButton()).not.toBeDisabled();
+});
+
+test("editing a row's time re-validates live and disables save on an overlap", () => {
+  render(<ScheduleBoard events={events} />);
+
+  // a's endTime (index 1: 09:00 start, 10:00 end) pushed past b's 10:00 start.
+  fireEvent.change(timeInputs()[1], { target: { value: "10:30" } });
+
+  expect(invalidWarning()).toBeInTheDocument();
+  expect(saveButton()).toBeDisabled();
+});
+
+test("saves the reordered board together with the edited time", async () => {
+  render(<ScheduleBoard events={events} />);
+
+  fireEvent.change(timeInputs()[1], { target: { value: "09:45" } });
+  fireEvent.click(saveButton());
+
+  await waitFor(() =>
+    expect(patchMock).toHaveBeenCalledWith("/admin/schedule/order", {
+      updates: [
+        { id: "a", day: 1, order: 0, startTime: "09:00", endTime: "09:45" },
+        { id: "b", day: 1, order: 1, startTime: "10:00", endTime: "11:00" },
+      ],
+    })
+  );
+  expect(toastSuccessMock).toHaveBeenCalledWith("Ordem guardada.");
+  expect(refreshMock).toHaveBeenCalled();
+});
+
+test("shows an error toast without navigating away when saving fails", async () => {
+  patchMock.mockRejectedValue(new Error("network down"));
+
+  render(<ScheduleBoard events={events} />);
+  fireEvent.click(saveButton());
+
+  await waitFor(() =>
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Não foi possível guardar a ordem."
+    )
+  );
+  expect(refreshMock).not.toHaveBeenCalled();
+});
+
+test("only the drag handle carries sortable listeners, not the time inputs", () => {
+  render(<ScheduleBoard events={events} />);
+
+  const handle = screen.getAllByLabelText("Arrastar para reordenar")[0];
+  expect(handle).toHaveAttribute("role", "button");
+  expect(handle).toHaveAttribute("tabindex", "0");
+
+  for (const input of timeInputs()) {
+    expect(input).not.toHaveAttribute("role");
+    expect(input).not.toHaveAttribute("aria-roledescription");
+  }
+});

--- a/src/components/ScheduleBoard/index.tsx
+++ b/src/components/ScheduleBoard/index.tsx
@@ -244,7 +244,7 @@ const ScheduleBoard: React.FC<ScheduleBoardProps> = ({ events }) => {
           type="button"
           onClick={handleSave}
           disabled={isSaving || invalidIds.size > 0}
-          className="rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isSaving ? "A guardar..." : "Guardar"}
         </button>

--- a/src/components/ScheduleBoard/index.tsx
+++ b/src/components/ScheduleBoard/index.tsx
@@ -20,6 +20,7 @@ import {
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import { MdDragIndicator } from "react-icons/md";
 import { toast } from "react-toastify";
 
 import { httpClient } from "@/lib/http/client";
@@ -74,31 +75,64 @@ function findContainer(board: Board, id: string): Day | undefined {
   return DAYS.find((day) => board[day].some((row) => row.id === id));
 }
 
-const ScheduleRowCard: React.FC<{ row: ScheduleRow; invalid?: boolean }> = ({
-  row,
-  invalid,
-}) => (
-  <div className="flex items-center gap-3 rounded-md border border-gray-300 bg-white p-2 shadow-sm">
-    <span
-      className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-xs font-semibold ${
-        invalid
-          ? "border-2 border-red-500 text-red-600"
-          : "border border-transparent text-gray-600"
-      }`}
-    >
-      {row.startTime}
-    </span>
-    <span className="text-xs text-gray-400">–{row.endTime}</span>
+const timeInputClassName = (invalid?: boolean) =>
+  `w-[4.5rem] shrink-0 rounded border bg-transparent px-1 py-0.5 font-mono text-xs font-semibold ${
+    invalid
+      ? "border-red-500 text-red-600"
+      : "border-transparent text-gray-600 hover:border-gray-300"
+  }`;
+
+const ScheduleRowCard: React.FC<{
+  row: ScheduleRow;
+  invalid?: boolean;
+  dragHandleProps?: React.HTMLAttributes<HTMLElement>;
+  onTimeChange?: (field: "startTime" | "endTime", value: string) => void;
+}> = ({ row, invalid, dragHandleProps, onTimeChange }) => (
+  <div className="flex items-center gap-2 rounded-md border border-gray-300 bg-white p-2 shadow-sm">
+    {dragHandleProps && (
+      <span
+        {...dragHandleProps}
+        className="shrink-0 cursor-grab touch-none text-gray-400 active:cursor-grabbing"
+        aria-label="Arrastar para reordenar"
+      >
+        <MdDragIndicator size={18} />
+      </span>
+    )}
+    {onTimeChange ? (
+      <>
+        <input
+          type="time"
+          value={row.startTime}
+          onChange={(e) => onTimeChange("startTime", e.target.value)}
+          onPointerDown={(e) => e.stopPropagation()}
+          className={timeInputClassName(invalid)}
+        />
+        <span className="text-xs text-gray-400">–</span>
+        <input
+          type="time"
+          value={row.endTime}
+          onChange={(e) => onTimeChange("endTime", e.target.value)}
+          onPointerDown={(e) => e.stopPropagation()}
+          className={timeInputClassName(invalid)}
+        />
+      </>
+    ) : (
+      <>
+        <span className={timeInputClassName(invalid)}>{row.startTime}</span>
+        <span className="text-xs text-gray-400">–{row.endTime}</span>
+      </>
+    )}
     <span className="truncate text-sm font-medium text-gray-800">
       {row.activity}
     </span>
   </div>
 );
 
-const SortableRow: React.FC<{ row: ScheduleRow; invalid: boolean }> = ({
-  row,
-  invalid,
-}) => {
+const SortableRow: React.FC<{
+  row: ScheduleRow;
+  invalid: boolean;
+  onTimeChange: (field: "startTime" | "endTime", value: string) => void;
+}> = ({ row, invalid, onTimeChange }) => {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: row.id });
 
@@ -106,10 +140,13 @@ const SortableRow: React.FC<{ row: ScheduleRow; invalid: boolean }> = ({
     <div
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
-      {...attributes}
-      {...listeners}
     >
-      <ScheduleRowCard row={row} invalid={invalid} />
+      <ScheduleRowCard
+        row={row}
+        invalid={invalid}
+        dragHandleProps={{ ...attributes, ...listeners }}
+        onTimeChange={onTimeChange}
+      />
     </div>
   );
 };
@@ -118,7 +155,12 @@ const DayLane: React.FC<{
   day: Day;
   rows: ScheduleRow[];
   invalidIds: Set<string>;
-}> = ({ day, rows, invalidIds }) => {
+  onTimeChange: (
+    rowId: string,
+    field: "startTime" | "endTime",
+    value: string
+  ) => void;
+}> = ({ day, rows, invalidIds, onTimeChange }) => {
   const { setNodeRef } = useDroppable({ id: String(day) });
 
   return (
@@ -136,6 +178,9 @@ const DayLane: React.FC<{
               key={row.id}
               row={row}
               invalid={invalidIds.has(row.id)}
+              onTimeChange={(field, value) =>
+                onTimeChange(row.id, field, value)
+              }
             />
           ))}
         </div>
@@ -216,9 +261,30 @@ const ScheduleBoard: React.FC<ScheduleBoardProps> = ({ events }) => {
     });
   };
 
+  const handleTimeChange = (
+    rowId: string,
+    field: "startTime" | "endTime",
+    value: string
+  ) => {
+    const container = findContainer(board, rowId);
+    if (!container) return;
+    setBoard((prev) => ({
+      ...prev,
+      [container]: prev[container].map((row) =>
+        row.id === rowId ? { ...row, [field]: value } : row
+      ),
+    }));
+  };
+
   const handleSave = async () => {
     const updates = DAYS.flatMap((day) =>
-      board[day].map((row, index) => ({ id: row.id, day, order: index }))
+      board[day].map((row, index) => ({
+        id: row.id,
+        day,
+        order: index,
+        startTime: row.startTime,
+        endTime: row.endTime,
+      }))
     );
     setIsSaving(true);
     try {
@@ -264,6 +330,7 @@ const ScheduleBoard: React.FC<ScheduleBoardProps> = ({ events }) => {
               day={day}
               rows={board[day]}
               invalidIds={invalidIds}
+              onTimeChange={handleTimeChange}
             />
           ))}
         </div>

--- a/src/components/ScheduleBoard/index.tsx
+++ b/src/components/ScheduleBoard/index.tsx
@@ -104,7 +104,6 @@ const ScheduleRowCard: React.FC<{
           type="time"
           value={row.startTime}
           onChange={(e) => onTimeChange("startTime", e.target.value)}
-          onPointerDown={(e) => e.stopPropagation()}
           className={timeInputClassName(invalid)}
         />
         <span className="text-xs text-gray-400">–</span>
@@ -112,7 +111,6 @@ const ScheduleRowCard: React.FC<{
           type="time"
           value={row.endTime}
           onChange={(e) => onTimeChange("endTime", e.target.value)}
-          onPointerDown={(e) => e.stopPropagation()}
           className={timeInputClassName(invalid)}
         />
       </>

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -10,7 +10,15 @@ import { LogIn } from "@/components/ui/Icons";
 import LogoutButton from "@/components/LogoutButton";
 import UserButton from "@/components/Profile/UserButton";
 
-const TopBar: React.FC = () => {
+interface TopBarProps {
+  // The admin backoffice is the only place TopBar sits on a light page
+  // background from the top instead of a dark hero - its white logo/icons
+  // and scroll-fading dark background were invisible there, not just low-
+  // contrast. Everywhere else keeps the existing dark styling unchanged.
+  light?: boolean;
+}
+
+const TopBar: React.FC<TopBarProps> = ({ light = false }) => {
   const { scrollYProgress } = useScroll();
   const session = useSession();
   const pathname = usePathname();
@@ -25,17 +33,25 @@ const TopBar: React.FC = () => {
 
   return (
     <nav className={`fixed z-40 h-16 w-full overflow-hidden`}>
-      <motion.div
-        className={`absolute top-0 left-0 flex h-16 w-screen items-center justify-between bg-background`}
-        style={{
-          opacity,
-        }}
-      />
+      {light ? (
+        <div className="absolute top-0 left-0 flex h-16 w-screen items-center justify-between border-b border-gray-200 bg-white" />
+      ) : (
+        <motion.div
+          className={`absolute top-0 left-0 flex h-16 w-screen items-center justify-between bg-background`}
+          style={{
+            opacity,
+          }}
+        />
+      )}
       <div className="absolute top-2 right-4 flex h-12 w-full items-center justify-between space-x-4 px-4 py-2">
         {!isAuthPage ? (
           <Link href="/" className="ml-6">
             <Image
-              src={"/assets/images/logo_white.svg"}
+              src={
+                light
+                  ? "/assets/images/logo_dark.png"
+                  : "/assets/images/logo_white.svg"
+              }
               alt="Fallstack"
               width={32}
               height={32}
@@ -49,14 +65,14 @@ const TopBar: React.FC = () => {
             <Link
               href={isAuthPage ? "/" : "/login"}
               aria-label={isAuthPage ? "Página inicial" : "Iniciar sessão"}
-              className="z-20 flex size-full items-center justify-center fill-white text-2xl transition-colors hover:text-primary"
+              className={`z-20 flex size-full items-center justify-center text-2xl transition-colors hover:text-primary ${light ? "fill-gray-700" : "fill-white"}`}
             >
               <LogIn />
             </Link>
           ) : (
             <>
-              <UserButton user={session.user} />
-              <LogoutButton />
+              <UserButton user={session.user} light={light} />
+              <LogoutButton light={light} />
             </>
           )}
         </div>

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -11,14 +11,17 @@ import LogoutButton from "@/components/LogoutButton";
 import UserButton from "@/components/Profile/UserButton";
 
 interface TopBarProps {
-  // The admin backoffice is the only place TopBar sits on a light page
-  // background from the top instead of a dark hero - its white logo/icons
-  // and scroll-fading dark background were invisible there, not just low-
-  // contrast. Everywhere else keeps the existing dark styling unchanged.
-  light?: boolean;
+  // The scroll-linked fade (transparent at the top, solidifying as you
+  // scroll) only makes sense over a hero image at the top of the page.
+  // The admin backoffice has no hero - it's a plain page from the very
+  // first pixel - so a fading-from-transparent bar there is invisible at
+  // the top instead of just low-contrast. `solid` skips the fade for an
+  // always-opaque background; the logo/icons stay the same dark-background
+  // white as everywhere else, since the background itself stays dark.
+  solid?: boolean;
 }
 
-const TopBar: React.FC<TopBarProps> = ({ light = false }) => {
+const TopBar: React.FC<TopBarProps> = ({ solid = false }) => {
   const { scrollYProgress } = useScroll();
   const session = useSession();
   const pathname = usePathname();
@@ -33,8 +36,8 @@ const TopBar: React.FC<TopBarProps> = ({ light = false }) => {
 
   return (
     <nav className={`fixed z-40 h-16 w-full overflow-hidden`}>
-      {light ? (
-        <div className="absolute top-0 left-0 flex h-16 w-screen items-center justify-between border-b border-gray-200 bg-white" />
+      {solid ? (
+        <div className="absolute top-0 left-0 flex h-16 w-screen items-center justify-between bg-background" />
       ) : (
         <motion.div
           className={`absolute top-0 left-0 flex h-16 w-screen items-center justify-between bg-background`}
@@ -47,11 +50,7 @@ const TopBar: React.FC<TopBarProps> = ({ light = false }) => {
         {!isAuthPage ? (
           <Link href="/" className="ml-6">
             <Image
-              src={
-                light
-                  ? "/assets/images/logo_dark.png"
-                  : "/assets/images/logo_white.svg"
-              }
+              src={"/assets/images/logo_white.svg"}
               alt="Fallstack"
               width={32}
               height={32}
@@ -65,14 +64,14 @@ const TopBar: React.FC<TopBarProps> = ({ light = false }) => {
             <Link
               href={isAuthPage ? "/" : "/login"}
               aria-label={isAuthPage ? "Página inicial" : "Iniciar sessão"}
-              className={`z-20 flex size-full items-center justify-center text-2xl transition-colors hover:text-primary ${light ? "fill-gray-700" : "fill-white"}`}
+              className="z-20 flex size-full items-center justify-center fill-white text-2xl transition-colors hover:text-primary"
             >
               <LogIn />
             </Link>
           ) : (
             <>
-              <UserButton user={session.user} light={light} />
-              <LogoutButton light={light} />
+              <UserButton user={session.user} />
+              <LogoutButton />
             </>
           )}
         </div>

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import useSession from "@/hooks/useSession";
+
+import { AuthContextProvider } from "./AuthContext";
+
+const { getSessionMock } = vi.hoisted(() => ({ getSessionMock: vi.fn() }));
+
+vi.mock("@/client/api/session", () => ({
+  default: () => getSessionMock(),
+}));
+
+const Probe: React.FC<{
+  onReady: (session: ReturnType<typeof useSession>) => void;
+}> = ({ onReady }) => {
+  const session = useSession();
+  onReady(session);
+  return <span>{session.user?.role ?? "none"}</span>;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("fetchSession() with no argument fetches the session from the network", async () => {
+  getSessionMock.mockResolvedValue({
+    role: "EMPLOYEE",
+    adminRole: null,
+    student: null,
+  });
+
+  // No initialUser -> the provider's own mount-time effect calls
+  // fetchSession() with no argument, exercising the same "go fetch it
+  // yourself" path a caller hits by calling it that way explicitly.
+  render(
+    <AuthContextProvider>
+      <Probe onReady={() => {}} />
+    </AuthContextProvider>
+  );
+
+  await waitFor(() => expect(getSessionMock).toHaveBeenCalledTimes(1));
+  await screen.findByText("EMPLOYEE");
+});
+
+test("fetchSession(user) sets the context from the given value without a network request", async () => {
+  let latestSession: ReturnType<typeof useSession> | undefined;
+
+  render(
+    <AuthContextProvider initialUser={null}>
+      <Probe
+        onReady={(session) => {
+          latestSession = session;
+        }}
+      />
+    </AuthContextProvider>
+  );
+
+  latestSession?.fetchSession({
+    role: "STUDENT",
+    adminRole: null,
+    student: null,
+  });
+
+  await screen.findByText("STUDENT");
+  expect(getSessionMock).not.toHaveBeenCalled();
+});

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,7 +8,12 @@ import getSession from "@/client/api/session";
 export interface AuthContextData {
   user: SessionDto | null;
   clear: () => void;
-  fetchSession: () => void;
+  // Refreshes the context's user. With no argument, fetches it from the
+  // session endpoint. Pass an already-fetched user (e.g. right after
+  // login, where the caller needs that same value for its own redirect
+  // decision) to update the context from it directly instead of firing a
+  // second, redundant request for data the caller already has.
+  fetchSession: (preFetchedUser?: SessionDto | null) => void;
 }
 
 interface AuthContextProviderProps {
@@ -25,8 +30,9 @@ export function AuthContextProvider({
 }: AuthContextProviderProps) {
   const [user, setUser] = useState<SessionDto | null>(initialUser ?? null);
 
-  const fetchSession = async () => {
-    const user = await getSession();
+  const fetchSession = async (preFetchedUser?: SessionDto | null) => {
+    const user =
+      preFetchedUser !== undefined ? preFetchedUser : await getSession();
     setUser(user);
   };
 

--- a/src/domain/schedule/scheduleValidation.test.ts
+++ b/src/domain/schedule/scheduleValidation.test.ts
@@ -50,6 +50,26 @@ test("a single valid row is fine on its own", () => {
   assert.equal(invalid.size, 0);
 });
 
+test("flags a row with a blank startTime, even as the first row of the day", () => {
+  // A blank first row's startTime sorts before everything else, so it
+  // never trips the "starts before the previous row ends" check (there is
+  // no previous row) - must be caught on its own, not just via ordering.
+  const invalid = findInvalidScheduleRowIds([
+    { id: "a", startTime: "", endTime: "10:00" },
+    { id: "b", startTime: "10:00", endTime: "11:00" },
+  ]);
+
+  assert.deepEqual([...invalid], ["a"]);
+});
+
+test("flags a row with a blank endTime", () => {
+  const invalid = findInvalidScheduleRowIds([
+    { id: "a", startTime: "09:00", endTime: "" },
+  ]);
+
+  assert.deepEqual([...invalid], ["a"]);
+});
+
 test("back-to-back rows (end equals next start) are valid, not an overlap", () => {
   const invalid = findInvalidScheduleRowIds([
     { id: "a", startTime: "09:00", endTime: "10:00" },

--- a/src/domain/schedule/scheduleValidation.ts
+++ b/src/domain/schedule/scheduleValidation.ts
@@ -6,7 +6,10 @@ export interface ScheduleRow {
 
 /**
  * Returns the ids of rows that are chronologically inconsistent within a
- * single day's ordered sequence: a row whose own end isn't after its own
+ * single day's ordered sequence: a row with a blank start/end (e.g. a time
+ * input cleared mid-edit - "" sorts before every other row's time, which
+ * would otherwise hide a blank *first* row's startTime from the
+ * previous-row check below), a row whose own end isn't after its own
  * start, or one that starts before the previous row (in display order) has
  * ended. `rows` must already be in the display order being validated -
  * this doesn't sort them itself, since "does the current order make sense"
@@ -17,6 +20,7 @@ export function findInvalidScheduleRowIds(rows: ScheduleRow[]): Set<string> {
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
+    if (!row.startTime || !row.endTime) invalid.add(row.id);
     if (row.endTime <= row.startTime) invalid.add(row.id);
     if (i > 0 && row.startTime < rows[i - 1].endTime) invalid.add(row.id);
   }

--- a/src/schemas/adminScheduleSchema.ts
+++ b/src/schemas/adminScheduleSchema.ts
@@ -37,6 +37,8 @@ export const updateScheduleOrderSchema = z.object({
       id: z.uuid(),
       day: daySchema,
       order: z.number().int(),
+      startTime: timeSchema.optional(),
+      endTime: timeSchema.optional(),
     })
   ),
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   oxc: {
@@ -19,6 +19,6 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
-    exclude: ["**/node_modules/**", ".claude/worktrees/**"],
+    exclude: [...configDefaults.exclude, ".claude/worktrees/**"],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,5 +19,6 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
+    exclude: ["**/node_modules/**", ".claude/worktrees/**"],
   },
 });


### PR DESCRIPTION
## Summary

Started from two bugs reported off a live screenshot of `/overview` (chart rendering as one stretched bar, topbar logo/icons invisible), then grew into a broader pass over the admin backoffice's look and a couple of functional gaps found along the way.

### Chart scaling (`AdminWeeklyActivityChart`)
The `<svg>` only had a `viewBox` plus Tailwind's `h-auto w-full` — without explicit `width`/`height` (or a CSS `aspect-ratio`), that's a fragile pattern for a percentage-width/auto-height SVG. Added explicit `width`/`height` matching the viewBox, plus an inline `aspect-ratio` as an independent safeguard. Also guarded `totalWidth` against going negative for an empty `data` array.

### Brand palette across the admin backoffice
The backoffice used generic Tailwind blue/white instead of the site's actual brand colors (`#141414` dark background, `#f97316` orange primary), and looked inconsistent with the rest of the site. Swept `bg-blue-500`/`hover:bg-blue-600`/`text-blue-500` → `bg-primary`/`hover:bg-primary/90`/`text-primary` across admin buttons and boards. `TopBar` gained a `solid` prop (an always-opaque dark background, skipping the scroll-linked fade that only makes sense over a hero image) instead of the transparent-fading bar that made the logo/icons briefly invisible on a page with no hero — the logo and icon fills stay the same white as everywhere else, since the background itself stays dark. Deliberately left untouched: `AdminToggleButton`'s green (a status color, not brand identity) and `QRCodeScanner` (not admin-related).

### Emoji icons → react-icons
The delete button, edit links, and activity feed used raw emoji (🗑, ✏️, 📷, ⭐) as icons, which render inconsistently across platforms. `react-icons` is already a project dependency — replaced them with `FiTrash2`/`FiEdit2`/`FiBookmark`/`FiCamera`/`FiUserPlus`.

### Admin login redirect
Logging in as an admin didn't redirect to the backoffice — it fell through to `/`. Root cause: the redirect logic read `session.user` from the `AuthContext` immediately after calling `session.fetchSession()`, but that function updates the context via `setState`, which only takes effect on React's *next* render, not synchronously in the same closure — so the redirect always saw the stale, pre-login session. This affected every role's redirect, not just admin. Fixed by fetching the session directly for the redirect decision, while still firing `fetchSession()` so the rest of the UI (TopBar, etc.) picks it up too.

### Distinct admin icon in the topbar
An admin session showed the same generic "your profile" person icon, even though the link opens the admin backoffice rather than a personal profile. Swapped in `MdOutlineAdminPanelSettings` for admin sessions, with a matching `aria-label`.

### Inline time editing on the schedule reorder board
Times were read-only on the drag-and-drop schedule board — fixing a start/end time meant leaving the board, editing the row on its own admin page, then coming back to reorder. `startTime`/`endTime` are now directly editable per row, feeding into the same live overlap validation the board already runs on drag, and saved together with the reorder through the existing `PATCH /admin/schedule/order` endpoint (schema, service, and repository extended to accept and persist optional per-row times). The drag listeners moved to a dedicated handle icon instead of the whole row, so clicking into a time input no longer starts a drag.

### Housekeeping: lint/test scope
`eslint .` and `vitest run` had no ignore for agent-created worktrees under `.claude/worktrees/` (or, for eslint, the generated PWA service-worker output in `public/`), so every worktree's full source tree — and its own `node_modules` — got linted/tested alongside this one. That's what was causing `pnpm lint`/`pnpm test` to time out or fail on unrelated state in this environment; excluded both.

## Review follow-ups

- **Critical (fixed): the brand-palette sweep didn't actually render orange.** Tailwind v4 only turns `@theme` keys under `--color-*` into utilities — `bg-primary`/`text-primary` were reading `--color-primary`, which held a translucent white, while the intended orange lived in a separate, disconnected `--primary: #f97316` only reachable via a manual `var(--primary)`. So every button this PR swept (and every other `bg-primary` use already on `dev`, e.g. `not-found.tsx`, `Schedule/index.tsx`) was rendering near-invisible instead of brand orange. Traced via git history to a same-day, same-author pair of commits (`60448b0` set it correctly, `2e04f5c` four minutes later accidentally reverted `--color-primary` while detaching `--primary` from it). Fixed in `src/app/globals.css`: `--color-primary` is the orange again, `--primary` is a plain alias of it. Verified by compiling `globals.css` through the project's actual `@tailwindcss/postcss` pipeline and confirming `bg-primary`/`text-primary` resolve to `#f97316`.
- **Minor (fixed): double session fetch on login.** `fetchSession()` now optionally accepts an already-fetched user and updates the context from it directly; the login page fetches once and passes that value to both the redirect decision and `fetchSession()`, instead of two independent `GET /auth/session` calls.
- **Minor (fixed): a cleared time input could bypass live validation.** `findInvalidScheduleRowIds` now flags a blank `startTime`/`endTime` directly — previously a blank `startTime` on a day's *first* row slipped past the "starts before the previous row ends" check (there's no previous row to compare against), so "Guardar" stayed enabled until the server's regex rejected it with a generic toast.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 261 passing, including the coverage above plus new tests for the restored session-fetch behavior (`AuthContext`) and the blank-time validation gap (`scheduleValidation`)
- [x] `pnpm dev` — boots cleanly, no runtime errors
- [ ] Live click-through of the admin UI (login redirect, topbar icon, palette — now actually orange, drag-and-drop time editing) — no browser automation available in this environment; please verify visually before merging


