### PR TITLE
fix: give admin logo previews a dark chip for contrast

### DIFF
--- a/src/app/(admin)/companies/page.tsx
+++ b/src/app/(admin)/companies/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 import { FiEdit2 } from "react-icons/fi";
 
@@ -6,6 +5,7 @@ import {
   parseAdminListParams,
   type AdminListSearchParams,
 } from "@/lib/adminListParams";
+import LogoThumbnail from "@/components/ui/LogoThumbnail";
 import AdminToggleButton from "@/components/AdminToggleButton";
 import DataTable, { type DataTableColumn } from "@/components/DataTable";
 import { toAdminCompanyDto } from "@/application/dto/companyDto";
@@ -24,15 +24,7 @@ const columns: DataTableColumn<CompanyRow>[] = [
     key: "avatar",
     header: "Logótipo",
     render: (company) =>
-      company.avatar ? (
-        <Image
-          src={company.avatar}
-          alt=""
-          width={40}
-          height={40}
-          className="size-10 rounded-full object-cover"
-        />
-      ) : null,
+      company.avatar ? <LogoThumbnail src={company.avatar} size={40} /> : null,
   },
   { key: "name", header: "Nome", render: (c) => c.name, sortable: true },
   { key: "tier", header: "Tier", render: (c) => c.tier, sortable: true },

--- a/src/app/(admin)/sponsors/page.tsx
+++ b/src/app/(admin)/sponsors/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 import { FiEdit2 } from "react-icons/fi";
 
@@ -6,6 +5,7 @@ import {
   parseAdminListParams,
   type AdminListSearchParams,
 } from "@/lib/adminListParams";
+import LogoThumbnail from "@/components/ui/LogoThumbnail";
 import AdminToggleButton from "@/components/AdminToggleButton";
 import DataTable, { type DataTableColumn } from "@/components/DataTable";
 import { toAdminSponsorDto } from "@/application/dto/sponsorDto";
@@ -23,15 +23,7 @@ const columns: DataTableColumn<SponsorRow>[] = [
   {
     key: "logo",
     header: "Logótipo",
-    render: (sponsor) => (
-      <Image
-        src={sponsor.logo}
-        alt=""
-        width={40}
-        height={40}
-        className="size-10 rounded-full object-cover"
-      />
-    ),
+    render: (sponsor) => <LogoThumbnail src={sponsor.logo} size={40} />,
   },
   { key: "name", header: "Nome", render: (s) => s.name, sortable: true },
   { key: "website", header: "Website", render: (s) => s.website ?? "-" },

--- a/src/components/AdminForm/index.tsx
+++ b/src/components/AdminForm/index.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useId, useState } from "react";
-import Image from "next/image";
 import { toast } from "react-toastify";
 
+import LogoThumbnail from "@/components/ui/LogoThumbnail";
 import { uploadAdminImage } from "@/client/api/adminUpload";
 
 export type AdminFormValue = string | number | boolean | string[];
@@ -208,13 +208,7 @@ const AdminFormImageField: React.FC<AdminFormImageFieldProps> = ({
   return (
     <div className="flex items-center gap-4">
       {currentUrl ? (
-        <Image
-          src={currentUrl}
-          alt=""
-          width={64}
-          height={64}
-          className="size-16 rounded-full object-cover"
-        />
+        <LogoThumbnail src={currentUrl} size={64} />
       ) : (
         <div className="flex size-16 items-center justify-center rounded-full bg-gray-100 text-center text-xs text-gray-400">
           Sem imagem

--- a/src/components/CompanyTierBoard/index.tsx
+++ b/src/components/CompanyTierBoard/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import {
   closestCenter,
@@ -24,6 +23,7 @@ import {
 import { toast } from "react-toastify";
 
 import { httpClient } from "@/lib/http/client";
+import LogoThumbnail from "@/components/ui/LogoThumbnail";
 import type { CompanyTier } from "@/domain/company/company-tier";
 
 import { CSS } from "@dnd-kit/utilities";
@@ -81,13 +81,7 @@ const CompanyRowCard: React.FC<{ company: CompanyRow; dragging?: boolean }> = ({
     }`}
   >
     {company.avatar ? (
-      <Image
-        src={company.avatar}
-        alt=""
-        width={32}
-        height={32}
-        className="size-8 shrink-0 rounded-full object-cover"
-      />
+      <LogoThumbnail src={company.avatar} size={32} />
     ) : (
       <div className="size-8 shrink-0 rounded-full bg-gray-200" />
     )}

--- a/src/components/ui/LogoThumbnail/index.test.tsx
+++ b/src/components/ui/LogoThumbnail/index.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import LogoThumbnail from ".";
+
+// The <img> has alt="" (decorative - the row/card next to it already names
+// the company), which strips it of an accessible "img" role, so it's
+// queried directly rather than via getByRole.
+test("renders the logo over a dark chip, not the surrounding card's own background", () => {
+  const { container } = render(<LogoThumbnail src="/logo.png" size={40} />);
+
+  const image = container.querySelector("img");
+  expect(image).toHaveAttribute("src");
+
+  // The chip, not the <img>, carries the dark background - a light/white
+  // logo on a transparent PNG needs this behind it for contrast, since it
+  // otherwise sits directly on whatever white card/table the admin
+  // backoffice renders it in.
+  const chip = image?.parentElement;
+  expect(chip).toHaveClass("bg-background");
+});
+
+test("sizes the chip and image to the requested size", () => {
+  const { container } = render(<LogoThumbnail src="/logo.png" size={64} />);
+
+  const image = container.querySelector("img");
+  const chip = image?.parentElement as HTMLElement;
+
+  expect(chip.style.width).toBe("64px");
+  expect(chip.style.height).toBe("64px");
+});

--- a/src/components/ui/LogoThumbnail/index.tsx
+++ b/src/components/ui/LogoThumbnail/index.tsx
@@ -1,0 +1,34 @@
+import Image from "next/image";
+
+interface LogoThumbnailProps {
+  src: string;
+  size: number;
+  className?: string;
+}
+
+// Company/sponsor logos are designed for the site's own dark background
+// (--color-background, the same #141414 every public page renders on) -
+// many are light/white artwork on a transparent PNG, which disappears
+// against the white cards/tables the admin backoffice uses to display
+// them. This dark chip, instead of the surrounding white, keeps them
+// visible there and matches how they actually look on the live site.
+const LogoThumbnail: React.FC<LogoThumbnailProps> = ({
+  src,
+  size,
+  className,
+}) => (
+  <div
+    className={`flex shrink-0 items-center justify-center rounded-full bg-background ${className ?? ""}`}
+    style={{ width: size, height: size }}
+  >
+    <Image
+      src={src}
+      alt=""
+      width={size}
+      height={size}
+      className="size-full rounded-full object-cover"
+    />
+  </div>
+);
+
+export default LogoThumbnail;


### PR DESCRIPTION
## Summary

A company/sponsor logo that's light/white artwork on a transparent PNG - designed for the site's own dark background (`--color-background`, the same `#141414` every public page renders on) - all but disappears when placed directly on the admin backoffice's white forms/cards/tables. Reported from a screenshot of a company's logo rendering as barely-visible white text on a white card.

The public-facing pages aren't affected (the company/sponsor grids sit on that same dark `bg-background`), so this was scoped entirely to the admin UI:
- `AdminForm`'s logo upload preview (used by both the Company and Sponsor edit forms)
- `CompanyTierBoard`'s drag-and-drop row card
- The companies and sponsors admin list tables' logo thumbnail column

Added a small shared `LogoThumbnail` component (`src/components/ui/LogoThumbnail`) that renders the logo over a dark circular chip instead of the surrounding white, and wired it into all four spots that were previously rendering the raw `<Image>` directly - keeping the fix in one place instead of four near-identical copies.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 263 passing, including new `LogoThumbnail` coverage (dark chip present behind the image, correctly sized)
- [ ] Live check of a light-logo company/sponsor in the admin UI (edit form, tier board, list page) — no browser automation available in this environment; please verify visually before merging