### PR TITLE
fix: give the admin backoffice its own default text color

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -20,7 +20,14 @@ export default async function AdminLayout({
   return (
     <SessionAuthLayout>
       <Topbar solid />
-      <div className="flex min-h-screen pt-16">
+      {/* The public site's :root sets a global white text color for its
+          dark theme (globals.css) - the admin backoffice is a light theme
+          on top of the same root, so anything here that doesn't set its
+          own text color (e.g. a plain outline button) silently inherits
+          that white instead, on a white page, and disappears. Setting the
+          light theme's own default here is the fix, not patching every
+          individual element that happens to omit a text color. */}
+      <div className="flex min-h-screen bg-gray-50 pt-16 text-gray-900">
         <AdminSidebar isSuperAdmin={session.adminRole === "SUPER_ADMIN"} />
         <main id="main-content" className="min-w-0 flex-1">
           {children}


### PR DESCRIPTION
## Summary

Reported from a screenshot of a button rendering as an invisible pill - just a faint gray border, no visible label.

Root cause: `globals.css`'s `:root` sets a global white text color for the public site's dark theme (`--text: #ffffff`). The admin backoffice (`src/app/(admin)/layout.tsx`) is a light theme sharing that same root, and never overrode the inherited default anywhere in its layout. Every admin element that sets its own text color explicitly (headings, sidebar links, the primary submit button) looks fine - but a plain outline/secondary control that never got an explicit `text-*` class silently inherits white-on-white instead:

- `DataTable`'s search button and pagination "Anterior"/"Seguinte" links (used on 11 admin list pages)
- `AdminForm`'s "Escolher imagem" file-picker label
- Several pages' secondary "Ordenar por tier"/"Ordenar" links and storage tab links

Fixed at the root instead of patching each element individually - the same category of fix as the earlier `--color-primary` token bug (#272) and the logo-thumbnail contrast fix (#273): `(admin)/layout.tsx`'s content wrapper now sets its own light-theme default (`bg-gray-50 text-gray-900`), so anything inside it that doesn't set its own color gets a sane dark default instead of falling through to the public site's white.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 261 passing (no existing test asserts on this layout's classes; this is a CSS-cascade fix, not new logic)
- [ ] Live check of DataTable's search/pagination buttons and AdminForm's "Escolher imagem" label in the admin UI — no browser automation available in this environment; please verify visually before merging