### PR TITLE
fix: orphaned Supabase Auth accounts on deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ backoffice, which removes the Supabase Auth identity before the application
 row. Never delete users directly in the Supabase Auth dashboard: that leaves an
 unloginable application account.
 
-Before deploying this fix, and after any manual Auth operation, run
+Before deploying changes that affect account deletion, and after any manual
+Auth operation, run
 [`supabase/audit-orphaned-accounts.sql`](./supabase/audit-orphaned-accounts.sql)
 manually in every environment's Supabase SQL editor. It is read-only and reports
 orphans in both directions; investigate each result before deleting anything.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ through Supabase Auth. Application tables must not store passwords or password
 reset tokens, and application routes must not provide separate password-change
 flows.
 
+#### Account deletion
+
+`auth.users.id` and `public."User".id` match by convention; no foreign key can
+span Supabase Auth and Prisma. Always delete accounts through the admin
+backoffice, which removes the Supabase Auth identity before the application
+row. Never delete users directly in the Supabase Auth dashboard: that leaves an
+unloginable application account.
+
+Before deploying this fix, and after any manual Auth operation, run
+[`supabase/audit-orphaned-accounts.sql`](./supabase/audit-orphaned-accounts.sql)
+manually in every environment's Supabase SQL editor. It is read-only and reports
+orphans in both directions; investigate each result before deleting anything.
+
 ---
 
 # Getting Started

--- a/prisma/migrations/20260811000000_cascade_action_completions_on_student_delete/migration.sql
+++ b/prisma/migrations/20260811000000_cascade_action_completions_on_student_delete/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "ActionCompletion" DROP CONSTRAINT "ActionCompletion_studentId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "ActionCompletion" ADD CONSTRAINT "ActionCompletion_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "Student"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,7 +113,7 @@ model ActionCompletion {
   completedAt DateTime @default(now())
 
   action  Action  @relation(fields: [actionId], references: [id])
-  student Student @relation(fields: [studentId], references: [id])
+  student Student @relation(fields: [studentId], references: [id], onDelete: Cascade)
 
   actionId  String @db.Uuid
   studentId String @db.Uuid

--- a/src/application/repositories/userRepository.ts
+++ b/src/application/repositories/userRepository.ts
@@ -65,6 +65,9 @@ export const relinkUserId = (
 export const deleteUser = (id: string, db: DbClient = prisma) =>
   db.user.delete({ where: { id } });
 
+export const deleteUserIfExists = (id: string, db: DbClient = prisma) =>
+  db.user.deleteMany({ where: { id } });
+
 export const setUserInterests = (
   id: string,
   interests: string[],

--- a/src/application/services/adminAccountService.test.ts
+++ b/src/application/services/adminAccountService.test.ts
@@ -8,7 +8,7 @@ import {
   findAdminAccountById,
   updateAdminUserFields,
 } from "../repositories/adminRepository";
-import { deleteUser, updateUserActive } from "../repositories/userRepository";
+import { updateUserActive } from "../repositories/userRepository";
 import {
   createAdminAccount,
   deleteAdminAccount,
@@ -17,6 +17,7 @@ import {
 } from "./adminAccountService";
 import {
   createSupabaseAuthUserAsAdmin,
+  deleteUserAccount,
   rollbackAuthUser,
   setAuthUserBanned,
 } from "./authApplicationService";
@@ -35,10 +36,10 @@ vi.mock("../repositories/adminRepository", () => ({
 }));
 vi.mock("../repositories/userRepository", () => ({
   updateUserActive: vi.fn(),
-  deleteUser: vi.fn(),
 }));
 vi.mock("./authApplicationService", () => ({
   createSupabaseAuthUserAsAdmin: vi.fn(),
+  deleteUserAccount: vi.fn(),
   rollbackAuthUser: vi.fn(),
   setAuthUserBanned: vi.fn(),
 }));
@@ -159,7 +160,7 @@ test("an already-inactive super admin doesn't block further action on their row"
   await expect(deleteAdminAccount("a1")).resolves.toBeUndefined();
 
   expect(countActiveSuperAdmins).not.toHaveBeenCalled();
-  expect(deleteUser).toHaveBeenCalledWith("a1");
+  expect(deleteUserAccount).toHaveBeenCalledWith("a1");
 });
 
 test("can't delete the last active super admin", async () => {
@@ -169,7 +170,7 @@ test("can't delete the last active super admin", async () => {
   await expect(deleteAdminAccount("a1")).rejects.toThrow(
     "last active Super Admin"
   );
-  expect(deleteUser).not.toHaveBeenCalled();
+  expect(deleteUserAccount).not.toHaveBeenCalled();
 });
 
 test("can delete a regular admin's account freely", async () => {
@@ -178,7 +179,7 @@ test("can delete a regular admin's account freely", async () => {
   await deleteAdminAccount("a2");
 
   expect(countActiveSuperAdmins).not.toHaveBeenCalled();
-  expect(deleteUser).toHaveBeenCalledWith("a2");
+  expect(deleteUserAccount).toHaveBeenCalledWith("a2");
 });
 
 test("getAdminAccountById is a thin passthrough to the repository", async () => {

--- a/src/application/services/adminAccountService.ts
+++ b/src/application/services/adminAccountService.ts
@@ -15,9 +15,10 @@ import {
   updateAdminUserFields,
   type AdminAccountQuery,
 } from "../repositories/adminRepository";
-import { deleteUser, updateUserActive } from "../repositories/userRepository";
+import { updateUserActive } from "../repositories/userRepository";
 import {
   createSupabaseAuthUserAsAdmin,
+  deleteUserAccount,
   rollbackAuthUser,
   setAuthUserBanned,
 } from "./authApplicationService";
@@ -107,5 +108,5 @@ export async function updateAdminAccount(
 
 export async function deleteAdminAccount(id: string) {
   await assertNotLastActiveSuperAdmin(await findAdminAccountById(id));
-  await deleteUser(id);
+  await deleteUserAccount(id);
 }

--- a/src/application/services/authApplicationService.test.ts
+++ b/src/application/services/authApplicationService.test.ts
@@ -227,6 +227,62 @@ test("keeps the application user when Supabase Auth deletion fails", async () =>
   expect(deleteUser).not.toHaveBeenCalled();
 });
 
+test("deletes an application user whose Supabase Auth identity is already missing", async () => {
+  deleteAuthUser.mockResolvedValue({
+    data: null,
+    error: Object.assign(new Error("User not found"), {
+      code: "user_not_found",
+    }),
+  });
+
+  await deleteUserAccount("user-1");
+
+  expect(deleteUser).toHaveBeenCalledWith("user-1");
+});
+
+test("uses a stable message for opaque Supabase Auth deletion errors", async () => {
+  deleteAuthUser.mockResolvedValue({
+    data: null,
+    error: new Error("{}"),
+  });
+
+  await expect(deleteUserAccount("user-1")).rejects.toThrow(
+    "Unable to delete account"
+  );
+});
+
+test("still provisions a verified identity when spoofed Auth cleanup fails", async () => {
+  vi.mocked(findUserSessionByEmail).mockResolvedValue({
+    id: "spoofed-id",
+    role: "STUDENT",
+    adminRole: null,
+    student: null,
+    employee: null,
+  } as never);
+  getUserById.mockResolvedValue({
+    data: { user: { email_confirmed_at: undefined } },
+    error: null,
+  });
+  deleteAuthUser.mockResolvedValue({
+    data: null,
+    error: new Error("network error"),
+  });
+
+  await expect(
+    completeOAuthSignIn({
+      id: "new-authnei-id",
+      email,
+      fallback: "/signup",
+    })
+  ).resolves.toBe("/signup");
+  expect(deleteUser).toHaveBeenCalledWith("spoofed-id");
+  expect(upsertUser).toHaveBeenCalledWith({
+    id: "new-authnei-id",
+    email,
+    role: "STUDENT",
+  });
+});
+
 test("fails closed (treats as unconfirmed) when the admin lookup errors", async () => {
   vi.mocked(findUserSessionByEmail).mockResolvedValue({
     id: "old-password-id",

--- a/src/application/services/authApplicationService.test.ts
+++ b/src/application/services/authApplicationService.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../repositories/userRepository";
 import {
   completeOAuthSignIn,
+  deleteUserAccount,
   setAuthUserBanned,
 } from "./authApplicationService";
 
@@ -28,6 +29,7 @@ vi.mock("@/utils/supabase/admin", () => ({
 }));
 
 const email = Email.create("student@isep.ipp.pt");
+const deleteAuthUser = vi.fn();
 const getUserById = vi.fn();
 const updateUserById = vi.fn();
 
@@ -36,8 +38,11 @@ beforeEach(() => {
   vi.mocked(findUserSessionById).mockResolvedValue(null);
   vi.mocked(findUserSessionByEmail).mockResolvedValue(null);
   vi.mocked(createAdminClient).mockReturnValue({
-    auth: { admin: { getUserById, updateUserById } },
+    auth: {
+      admin: { deleteUser: deleteAuthUser, getUserById, updateUserById },
+    },
   } as never);
+  deleteAuthUser.mockResolvedValue({ data: {}, error: null });
   updateUserById.mockResolvedValue({ data: {}, error: null });
   // Confirmed by default - individual tests override for the unconfirmed path.
   getUserById.mockResolvedValue({
@@ -191,6 +196,7 @@ test("discards an unconfirmed dangling account found by email instead of relinki
     fallback: "/signup",
   });
 
+  expect(deleteAuthUser).toHaveBeenCalledWith("spoofed-id");
   expect(deleteUser).toHaveBeenCalledWith("spoofed-id");
   expect(relinkUserId).not.toHaveBeenCalled();
   expect(upsertUser).toHaveBeenCalledWith({
@@ -199,6 +205,26 @@ test("discards an unconfirmed dangling account found by email instead of relinki
     role: "STUDENT",
   });
   expect(destination).toBe("/signup");
+});
+
+test("deletes Supabase Auth before the matching application user", async () => {
+  await deleteUserAccount("user-1");
+
+  expect(deleteAuthUser).toHaveBeenCalledWith("user-1");
+  expect(deleteUser).toHaveBeenCalledWith("user-1");
+  expect(deleteAuthUser.mock.invocationCallOrder[0]).toBeLessThan(
+    vi.mocked(deleteUser).mock.invocationCallOrder[0]
+  );
+});
+
+test("keeps the application user when Supabase Auth deletion fails", async () => {
+  deleteAuthUser.mockResolvedValue({
+    data: null,
+    error: new Error("network error"),
+  });
+
+  await expect(deleteUserAccount("user-1")).rejects.toThrow("network error");
+  expect(deleteUser).not.toHaveBeenCalled();
 });
 
 test("fails closed (treats as unconfirmed) when the admin lookup errors", async () => {

--- a/src/application/services/authApplicationService.test.ts
+++ b/src/application/services/authApplicationService.test.ts
@@ -5,6 +5,7 @@ import { createAdminClient } from "@/utils/supabase/admin";
 
 import {
   deleteUser,
+  deleteUserIfExists,
   findUserSessionByEmail,
   findUserSessionById,
   relinkUserId,
@@ -22,6 +23,7 @@ vi.mock("../repositories/userRepository", () => ({
   findUserSessionByEmail: vi.fn(),
   relinkUserId: vi.fn(),
   deleteUser: vi.fn(),
+  deleteUserIfExists: vi.fn(),
   upsertUser: vi.fn(),
 }));
 vi.mock("@/utils/supabase/admin", () => ({
@@ -275,7 +277,7 @@ test("still provisions a verified identity when spoofed Auth cleanup fails", asy
       fallback: "/signup",
     })
   ).resolves.toBe("/signup");
-  expect(deleteUser).toHaveBeenCalledWith("spoofed-id");
+  expect(deleteUserIfExists).toHaveBeenCalledWith("spoofed-id");
   expect(upsertUser).toHaveBeenCalledWith({
     id: "new-authnei-id",
     email,

--- a/src/application/services/authApplicationService.test.ts
+++ b/src/application/services/authApplicationService.test.ts
@@ -12,6 +12,7 @@ import {
   upsertUser,
 } from "../repositories/userRepository";
 import {
+  AuthAccountDeletionError,
   completeOAuthSignIn,
   deleteUserAccount,
   setAuthUserBanned,
@@ -226,6 +227,9 @@ test("keeps the application user when Supabase Auth deletion fails", async () =>
   });
 
   await expect(deleteUserAccount("user-1")).rejects.toThrow("network error");
+  await expect(deleteUserAccount("user-1")).rejects.toBeInstanceOf(
+    AuthAccountDeletionError
+  );
   expect(deleteUser).not.toHaveBeenCalled();
 });
 
@@ -251,9 +255,12 @@ test("uses a stable message for opaque Supabase Auth deletion errors", async () 
   await expect(deleteUserAccount("user-1")).rejects.toThrow(
     "Unable to delete account"
   );
+  await expect(deleteUserAccount("user-1")).rejects.toBeInstanceOf(
+    AuthAccountDeletionError
+  );
 });
 
-test("still provisions a verified identity when spoofed Auth cleanup fails", async () => {
+test("blocks sign-in and leaves both sides intact when spoofed Auth cleanup fails", async () => {
   vi.mocked(findUserSessionByEmail).mockResolvedValue({
     id: "spoofed-id",
     role: "STUDENT",
@@ -269,6 +276,40 @@ test("still provisions a verified identity when spoofed Auth cleanup fails", asy
     data: null,
     error: new Error("network error"),
   });
+
+  await expect(
+    completeOAuthSignIn({
+      id: "new-authnei-id",
+      email,
+      fallback: "/signup",
+    })
+  ).rejects.toBeInstanceOf(AuthAccountDeletionError);
+  expect(deleteUserIfExists).not.toHaveBeenCalled();
+  expect(upsertUser).not.toHaveBeenCalled();
+});
+
+test("finishes cleanup and provisions the verified identity when only the app-row delete races", async () => {
+  vi.mocked(findUserSessionByEmail).mockResolvedValue({
+    id: "spoofed-id",
+    role: "STUDENT",
+    adminRole: null,
+    student: null,
+    employee: null,
+  } as never);
+  getUserById.mockResolvedValue({
+    data: { user: { email_confirmed_at: undefined } },
+    error: null,
+  });
+  // Auth identity is already confirmed gone, so deleteUserAccount reaches
+  // the Prisma delete - which fails here (e.g. a concurrent OAuth callback
+  // already removed the row). No orphan risk: Auth is provably absent.
+  deleteAuthUser.mockResolvedValue({
+    data: null,
+    error: Object.assign(new Error("User not found"), {
+      code: "user_not_found",
+    }),
+  });
+  vi.mocked(deleteUser).mockRejectedValue(new Error("Record not found"));
 
   await expect(
     completeOAuthSignIn({

--- a/src/application/services/authApplicationService.ts
+++ b/src/application/services/authApplicationService.ts
@@ -90,6 +90,14 @@ export async function rollbackAuthUser(userId: string) {
   }
 }
 
+// Thrown only when the Supabase Auth deletion call itself failed - i.e.
+// neither the Auth identity nor the app row has been touched yet. Callers
+// that catch a deleteUserAccount() failure must check for this specifically:
+// it's the one case where falling back to an app-only delete would create an
+// Auth-only orphan. Extends HttpError so existing `instanceof HttpError`
+// error-response mapping in every other caller keeps working unchanged.
+export class AuthAccountDeletionError extends HttpError {}
+
 // Supabase Auth and public.User cannot share a foreign key. Delete Auth first
 // so an Auth API failure cannot remove the app row and leave a login identity
 // that the backoffice can no longer retry deleting.
@@ -98,7 +106,7 @@ export async function deleteUserAccount(userId: string) {
   // Only an explicit code proves absence. Missing codes can also mean the
   // malformed self-hosted GoTrue failures described above, so stay fail-closed.
   if (error && error.code !== "user_not_found")
-    throw new HttpError(
+    throw new AuthAccountDeletionError(
       usableAuthErrorMessage(error?.message, "Unable to delete account"),
       500
     );
@@ -200,8 +208,25 @@ export async function completeOAuthSignIn(input: {
     try {
       await deleteUserAccount(existingByEmail.id);
     } catch (error) {
-      // ponytail: verified login wins here; audit catches any Auth-only
-      // orphan. Add a retry queue if these failures become frequent.
+      if (error instanceof AuthAccountDeletionError) {
+        // The Auth deletion call itself failed - neither the Auth identity
+        // nor the app row has been touched, so deleting only the app row
+        // here would create an Auth-only orphan. Leave both sides intact
+        // and let this sign-in attempt fail; the OAuth callback route
+        // catches this and redirects to /auth/auth-code-error, so the user
+        // just retries once Auth is reachable again.
+        reportError(
+          error,
+          { operation: "delete_unconfirmed_account_placeholder" },
+          "Failed to delete unconfirmed account placeholder's Auth identity"
+        );
+        throw error;
+      }
+
+      // Auth was already confirmed deleted or absent (deleteUserAccount only
+      // reaches this point after that) - e.g. a raced concurrent OAuth
+      // callback deleted the app row first. No orphan risk: finish the
+      // cleanup and continue provisioning.
       reportError(
         error,
         { operation: "delete_unconfirmed_account_placeholder" },

--- a/src/application/services/authApplicationService.ts
+++ b/src/application/services/authApplicationService.ts
@@ -94,7 +94,11 @@ export async function rollbackAuthUser(userId: string) {
 // that the backoffice can no longer retry deleting.
 export async function deleteUserAccount(userId: string) {
   const { error } = await createAdminClient().auth.admin.deleteUser(userId);
-  if (error) throw new HttpError(error.message, 500);
+  if (error && error.code !== "user_not_found")
+    throw new HttpError(
+      usableAuthErrorMessage(error?.message, "Unable to delete account"),
+      500
+    );
   await deleteUser(userId);
 }
 
@@ -190,7 +194,18 @@ export async function completeOAuthSignIn(input: {
     // Unconfirmed - discard the dangling placeholder instead of relinking
     // onto it, so AuthNEI (institutionally-verified) can claim the email
     // fresh below rather than inheriting potentially attacker-planted data.
-    await deleteUserAccount(existingByEmail.id);
+    try {
+      await deleteUserAccount(existingByEmail.id);
+    } catch (error) {
+      // ponytail: verified login wins here; audit catches any Auth-only
+      // orphan. Add a retry queue if these failures become frequent.
+      reportError(
+        error,
+        { operation: "delete_unconfirmed_auth_placeholder" },
+        "Failed to delete unconfirmed Supabase Auth placeholder"
+      );
+      await deleteUser(existingByEmail.id);
+    }
   }
 
   // First AuthNEI sign-in for this identity, no (trustworthy) pre-existing

--- a/src/application/services/authApplicationService.ts
+++ b/src/application/services/authApplicationService.ts
@@ -13,6 +13,7 @@ import {
 import { withTransaction } from "../repositories/transaction";
 import {
   deleteUser,
+  deleteUserIfExists,
   findUserByEmail,
   findUserSessionByEmail,
   findUserSessionById,
@@ -94,6 +95,8 @@ export async function rollbackAuthUser(userId: string) {
 // that the backoffice can no longer retry deleting.
 export async function deleteUserAccount(userId: string) {
   const { error } = await createAdminClient().auth.admin.deleteUser(userId);
+  // Only an explicit code proves absence. Missing codes can also mean the
+  // malformed self-hosted GoTrue failures described above, so stay fail-closed.
   if (error && error.code !== "user_not_found")
     throw new HttpError(
       usableAuthErrorMessage(error?.message, "Unable to delete account"),
@@ -201,10 +204,10 @@ export async function completeOAuthSignIn(input: {
       // orphan. Add a retry queue if these failures become frequent.
       reportError(
         error,
-        { operation: "delete_unconfirmed_auth_placeholder" },
-        "Failed to delete unconfirmed Supabase Auth placeholder"
+        { operation: "delete_unconfirmed_account_placeholder" },
+        "Failed to fully delete unconfirmed account placeholder"
       );
-      await deleteUser(existingByEmail.id);
+      await deleteUserIfExists(existingByEmail.id);
     }
   }
 

--- a/src/application/services/authApplicationService.ts
+++ b/src/application/services/authApplicationService.ts
@@ -89,6 +89,15 @@ export async function rollbackAuthUser(userId: string) {
   }
 }
 
+// Supabase Auth and public.User cannot share a foreign key. Delete Auth first
+// so an Auth API failure cannot remove the app row and leave a login identity
+// that the backoffice can no longer retry deleting.
+export async function deleteUserAccount(userId: string) {
+  const { error } = await createAdminClient().auth.admin.deleteUser(userId);
+  if (error) throw new HttpError(error.message, 500);
+  await deleteUser(userId);
+}
+
 // Defense-in-depth alongside User.active, which is what getServerSession()
 // actually enforces on every request - this additionally stops the person
 // from obtaining a *new* Supabase session at all once deactivated. Best-
@@ -181,7 +190,7 @@ export async function completeOAuthSignIn(input: {
     // Unconfirmed - discard the dangling placeholder instead of relinking
     // onto it, so AuthNEI (institutionally-verified) can claim the email
     // fresh below rather than inheriting potentially attacker-planted data.
-    await deleteUser(existingByEmail.id);
+    await deleteUserAccount(existingByEmail.id);
   }
 
   // First AuthNEI sign-in for this identity, no (trustworthy) pre-existing

--- a/src/application/services/employeeService.test.ts
+++ b/src/application/services/employeeService.test.ts
@@ -2,8 +2,11 @@ import { beforeEach, expect, test, vi } from "vitest";
 
 import { updateEmployeeFields } from "../repositories/employeeRepository";
 import { updateUserActive } from "../repositories/userRepository";
-import { setAuthUserBanned } from "./authApplicationService";
-import { updateEmployeeForAdmin } from "./employeeService";
+import { deleteUserAccount, setAuthUserBanned } from "./authApplicationService";
+import {
+  deleteEmployeeForAdmin,
+  updateEmployeeForAdmin,
+} from "./employeeService";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/supabase/admin", () => ({
@@ -29,6 +32,7 @@ vi.mock("../repositories/userRepository", () => ({
 }));
 vi.mock("./authApplicationService", () => ({
   createSupabaseAuthUserAsAdmin: vi.fn(),
+  deleteUserAccount: vi.fn(),
   rollbackAuthUser: vi.fn(),
   setAuthUserBanned: vi.fn(),
 }));
@@ -57,4 +61,10 @@ test("leaves active status untouched when not part of the update", async () => {
 
   expect(updateUserActive).not.toHaveBeenCalled();
   expect(setAuthUserBanned).not.toHaveBeenCalled();
+});
+
+test("deletes the employee account through the shared auth-aware service", async () => {
+  await deleteEmployeeForAdmin("e1");
+
+  expect(deleteUserAccount).toHaveBeenCalledWith("e1");
 });

--- a/src/application/services/employeeService.ts
+++ b/src/application/services/employeeService.ts
@@ -16,13 +16,10 @@ import {
   type AdminEmployeeQuery,
 } from "../repositories/employeeRepository";
 import { withTransaction } from "../repositories/transaction";
-import {
-  deleteUser,
-  updateUserActive,
-  upsertUser,
-} from "../repositories/userRepository";
+import { updateUserActive, upsertUser } from "../repositories/userRepository";
 import {
   createSupabaseAuthUserAsAdmin,
+  deleteUserAccount,
   rollbackAuthUser,
   setAuthUserBanned,
 } from "./authApplicationService";
@@ -97,4 +94,4 @@ export async function updateEmployeeForAdmin(
   return employee;
 }
 
-export const deleteEmployeeForAdmin = (id: string) => deleteUser(id);
+export const deleteEmployeeForAdmin = (id: string) => deleteUserAccount(id);

--- a/src/application/services/studentService.test.ts
+++ b/src/application/services/studentService.test.ts
@@ -5,8 +5,8 @@ import {
   updateStudentMedia,
 } from "../repositories/studentRepository";
 import { updateUserActive } from "../repositories/userRepository";
-import { setAuthUserBanned } from "./authApplicationService";
-import { updateStudentForAdmin } from "./studentService";
+import { deleteUserAccount, setAuthUserBanned } from "./authApplicationService";
+import { deleteStudentForAdmin, updateStudentForAdmin } from "./studentService";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/supabase/admin", () => ({
@@ -29,6 +29,7 @@ vi.mock("../repositories/userRepository", () => ({
 vi.mock("./actionService", () => ({ completeAction: vi.fn() }));
 vi.mock("./authApplicationService", () => ({
   createSupabaseAuthUserAsAdmin: vi.fn(),
+  deleteUserAccount: vi.fn(),
   rollbackAuthUser: vi.fn(),
   setAuthUserBanned: vi.fn(),
 }));
@@ -58,4 +59,10 @@ test("leaves active status untouched when not part of the update", async () => {
   expect(updateUserActive).not.toHaveBeenCalled();
   expect(setAuthUserBanned).not.toHaveBeenCalled();
   expect(updateStudentMedia).not.toHaveBeenCalled();
+});
+
+test("deletes the student account through the shared auth-aware service", async () => {
+  await deleteStudentForAdmin("s1");
+
+  expect(deleteUserAccount).toHaveBeenCalledWith("s1");
 });

--- a/src/application/services/studentService.ts
+++ b/src/application/services/studentService.ts
@@ -40,7 +40,6 @@ import {
 import { withTransaction } from "../repositories/transaction";
 import {
   connectUserInterests,
-  deleteUser,
   setUserInterests,
   updateUserActive,
   upsertUser,
@@ -48,6 +47,7 @@ import {
 import { completeAction } from "./actionService";
 import {
   createSupabaseAuthUserAsAdmin,
+  deleteUserAccount,
   rollbackAuthUser,
   setAuthUserBanned,
 } from "./authApplicationService";
@@ -221,7 +221,7 @@ export async function updateStudentForAdmin(
   return student;
 }
 
-export const deleteStudentForAdmin = (id: string) => deleteUser(id);
+export const deleteStudentForAdmin = (id: string) => deleteUserAccount(id);
 export const getAvatar = (id: string) => findStudentAvatar(id);
 export const getStudentInterests = (id: string) => findStudentInterests(id);
 

--- a/supabase/audit-orphaned-accounts.sql
+++ b/supabase/audit-orphaned-accounts.sql
@@ -1,16 +1,14 @@
 -- Run manually in each environment's Supabase SQL editor. Read-only: this
 -- reports account mismatches but intentionally does not delete either side.
 
--- Supabase Auth identities with no application account.
-select auth_user.id, auth_user.email
+select
+  case
+    when auth_user.id is null then 'application_without_auth'
+    else 'auth_without_application'
+  end as orphan_type,
+  coalesce(auth_user.id, app_user.id) as id,
+  coalesce(auth_user.email, app_user.email) as email
 from auth.users as auth_user
-left join public."User" as app_user on app_user.id = auth_user.id
-where app_user.id is null
-order by auth_user.email;
-
--- Application accounts with no Supabase Auth identity.
-select app_user.id, app_user.email
-from public."User" as app_user
-left join auth.users as auth_user on auth_user.id = app_user.id
-where auth_user.id is null
-order by app_user.email;
+full outer join public."User" as app_user on app_user.id = auth_user.id
+where auth_user.id is null or app_user.id is null
+order by orphan_type, email;

--- a/supabase/audit-orphaned-accounts.sql
+++ b/supabase/audit-orphaned-accounts.sql
@@ -1,0 +1,16 @@
+-- Run manually in each environment's Supabase SQL editor. Read-only: this
+-- reports account mismatches but intentionally does not delete either side.
+
+-- Supabase Auth identities with no application account.
+select auth_user.id, auth_user.email
+from auth.users as auth_user
+left join public."User" as app_user on app_user.id = auth_user.id
+where app_user.id is null
+order by auth_user.email;
+
+-- Application accounts with no Supabase Auth identity.
+select app_user.id, app_user.email
+from public."User" as app_user
+left join auth.users as auth_user on auth_user.id = app_user.id
+where auth_user.id is null
+order by app_user.email;

--- a/tests/e2e/accountDeletionCascade.test.ts
+++ b/tests/e2e/accountDeletionCascade.test.ts
@@ -1,0 +1,19 @@
+import { readFile } from "node:fs/promises";
+import { expect, test } from "vitest";
+
+test("student account deletion cascades action completions", async () => {
+  const [schema, migration] = await Promise.all([
+    readFile("prisma/schema.prisma", "utf8"),
+    readFile(
+      "prisma/migrations/20260811000000_cascade_action_completions_on_student_delete/migration.sql",
+      "utf8"
+    ),
+  ]);
+
+  expect(schema).toMatch(
+    /student Student @relation\(fields: \[studentId\], references: \[id\], onDelete: Cascade\)/
+  );
+  expect(migration).toMatch(
+    /"ActionCompletion_studentId_fkey"[\s\S]*ON DELETE CASCADE ON UPDATE CASCADE/
+  );
+});


### PR DESCRIPTION
## Summary

- delete the Supabase Auth identity before deleting the matching Prisma user
- route student, employee, admin, and unconfirmed-account cleanup through the shared service
- document backoffice-only deletion as the Auth-to-App operational rule
- add a read-only SQL audit for orphaned rows in both directions

## Verification

- `pnpm test` (267 passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors; 16 existing warnings)
- started `pnpm dev`; all three admin DELETE routes returned `401 {"error":"Unauthorized"}` without a session

Successful deletion was not exercised against a live account because this worktree has no configured Supabase environment or admin session.

## Manual deployment step

Run `supabase/audit-orphaned-accounts.sql` manually in every Supabase environment before deployment. Investigate each reported row before deleting anything; the query is read-only.