### PR TITLE
fix: log unexpected errors in httpErrorResponse's fallback

### DIFF
--- a/src/lib/http/server.test.ts
+++ b/src/lib/http/server.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { beforeEach, test, vi } from "vitest";
+import { z } from "zod";
+
+import { HttpError } from "@/types/HttpError";
+import { reportError } from "@/lib/logger";
+
+import { httpErrorResponse } from "./server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({ reportError: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(reportError).mockClear();
+});
+
+test("reports unexpected errors and returns a generic 500", async () => {
+  const error = new Error("boom");
+
+  const response = httpErrorResponse(error);
+
+  assert.equal(response.status, 500);
+  assert.deepEqual(await response.json(), { error: "Something went wrong" });
+  assert.equal(vi.mocked(reportError).mock.calls.length, 1);
+  assert.equal(vi.mocked(reportError).mock.calls[0][0], error);
+});
+
+test("does not report expected HttpError instances", async () => {
+  const error = new HttpError("Not found", 404);
+
+  const response = httpErrorResponse(error);
+
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), { error: "Not found" });
+  assert.equal(vi.mocked(reportError).mock.calls.length, 0);
+});
+
+test("does not report Zod validation errors", async () => {
+  const { error } = z.object({ name: z.string() }).safeParse({});
+
+  const response = httpErrorResponse(error);
+
+  assert.equal(response.status, 400);
+  assert.equal(vi.mocked(reportError).mock.calls.length, 0);
+});

--- a/src/lib/http/server.test.ts
+++ b/src/lib/http/server.test.ts
@@ -22,7 +22,11 @@ test("reports unexpected errors and returns a generic 500", async () => {
   assert.equal(response.status, 500);
   assert.deepEqual(await response.json(), { error: "Something went wrong" });
   assert.equal(vi.mocked(reportError).mock.calls.length, 1);
-  assert.equal(vi.mocked(reportError).mock.calls[0][0], error);
+  assert.deepEqual(vi.mocked(reportError).mock.calls[0], [
+    error,
+    { operation: "unhandled_route_error" },
+    "Unhandled error in route handler",
+  ]);
 });
 
 test("does not report expected HttpError instances", async () => {
@@ -41,5 +45,6 @@ test("does not report Zod validation errors", async () => {
   const response = httpErrorResponse(error);
 
   assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: error!.issues });
   assert.equal(vi.mocked(reportError).mock.calls.length, 0);
 });

--- a/src/lib/http/server.ts
+++ b/src/lib/http/server.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { ZodError, ZodType } from "zod";
 
 import { HttpError } from "@/types/HttpError";
+import { reportError } from "@/lib/logger";
 import getServerSession from "@/application/services/sessionService";
 import { AuthPolicy, passesAuthPolicy } from "@/domain/auth/authPolicy";
 
@@ -15,6 +16,12 @@ export const httpErrorResponse = (error: unknown) => {
     );
   if (error instanceof ZodError)
     return NextResponse.json({ error: error.issues }, { status: 400 });
+
+  reportError(
+    error,
+    { operation: "unhandled_route_error" },
+    "Unhandled error in route handler"
+  );
   return NextResponse.json({ error: "Something went wrong" }, { status: 500 });
 };
 


### PR DESCRIPTION
## Summary

- log unexpected errors in `httpErrorResponse`'s generic 500 branch via `reportError()`, so they're never silently swallowed regardless of whether the throwing route/service remembered to log it itself
- leave the `HttpError` and `ZodError` branches untouched — those are expected, deliberate control flow (auth/ownership rejections, validation failures), not something actually broken
- add `src/lib/http/server.test.ts` (no prior test file for this module), covering all three branches: unexpected error is reported and returns 500, `HttpError` is not reported and returns its own status, `ZodError` is not reported and returns 400

Closes #295

## Verification

- `pnpm test` (266 passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors)

Not exercised against a live route: the fix is a small, pure change to a single shared function already covered directly by the three added unit tests (all three branches, real `Error`/`HttpError`/`ZodError` inputs, asserting both the returned response and whether `reportError` fires). Did not additionally trigger a genuine unhandled exception through `pnpm dev` against a real route.