### PR TITLE
feat: add CV auto-purge job with in-app retention notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,35 @@ group by bucket_id;
 `pg_net` responses expire after six hours by default, so inspect them soon after
 the run. A candidate count that does not shrink indicates persistent failures.
 
+### CV retention purge
+
+Student CVs are purged twice a year, on May 1 and Nov 1 at 02:00 UTC, once
+`Student.cvUploadedAt` is more than 6 months old. The job only clears the DB
+reference (`cv = NULL`, `cvPurgedAt = now()`); the CV upload path stamps
+`cvUploadedAt` and clears `cvPurgedAt` on every successful upload. A profile
+banner tells the student their CV was removed whenever `cvPurgedAt` is set.
+
+1. Run [`supabase/cv-retention-purge.sql`](./supabase/cv-retention-purge.sql)
+   manually in the hosted Supabase SQL editor. Its final query is
+   non-destructive and returns the exact candidate set.
+2. Check every returned row against `Student.cv`/`Student.cvUploadedAt`. The
+   installer intentionally does not schedule the purge.
+3. Only after confirming the dry run, run
+   [`supabase/cv-retention-purge-enable.sql`](./supabase/cv-retention-purge-enable.sql)
+   manually.
+4. Confirm the job exists with:
+
+   ```sql
+   select jobid, schedule, command, active
+   from cron.job
+   where jobname = 'cv-retention-purge';
+   ```
+
+The purge only clears the DB reference; it does not delete the storage object.
+It runs at 02:00 UTC, one hour before the orphaned-file GC job's daily 03:00
+UTC run (above), so the now-unreferenced CV object is deleted the same day
+instead of waiting on its own cadence.
+
 ---
 
 # Supabase CLI (Local Development)

--- a/prisma/migrations/20260809105934_add_student_cv_retention/migration.sql
+++ b/prisma/migrations/20260809105934_add_student_cv_retention/migration.sql
@@ -1,3 +1,10 @@
 -- AlterTable
 ALTER TABLE "Student" ADD COLUMN     "cvUploadedAt" TIMESTAMP(3),
 ADD COLUMN     "cvPurgedAt" TIMESTAMP(3);
+
+-- Backfill: a CV uploaded before this column existed has no cvUploadedAt,
+-- which would make it permanently un-purgeable (NULL < anything is never
+-- true in the retention job's candidate query). Stamping it as of this
+-- migration gives every existing CV a full 6-month grace period instead of
+-- an immediate mass purge on the next scheduled run.
+UPDATE "Student" SET "cvUploadedAt" = CURRENT_TIMESTAMP WHERE "cv" IS NOT NULL AND "cvUploadedAt" IS NULL;

--- a/prisma/migrations/20260809105934_add_student_cv_retention/migration.sql
+++ b/prisma/migrations/20260809105934_add_student_cv_retention/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Student" ADD COLUMN     "cvUploadedAt" TIMESTAMP(3),
+ADD COLUMN     "cvPurgedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,21 +37,30 @@ model Student {
   id   String @id @db.Uuid
   user User   @relation(fields: [id], references: [id], onDelete: Cascade)
 
-  code      String   @unique
-  name      String
-  bio       String?
-  year      Year
+  code         String    @unique
+  name         String
+  bio          String?
+  year         Year
   // avatar/cv are bare Supabase Storage file IDs with no DB-level integrity
   // (no referential constraint, no cascade cleanup) - the root cause of the
   // orphaned-file GC job tracked separately in #37. Consider an Upload
   // tracking table if that gap needs closing; until then the GC job is the
   // only thing keeping storage in sync with these columns.
-  cv        String?
-  linkedin  String?
-  github    String?
-  avatar    String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  cv           String?
+  // Set on every successful CV upload, cleared back to null on purge -
+  // updatedAt isn't CV-specific (bumped by any profile edit), so the
+  // twice-yearly retention purge (#286) needs its own clock to tell which
+  // CVs are genuinely older than 6 months.
+  cvUploadedAt DateTime?
+  // Stamped by the retention purge when it nulls out `cv`; drives the
+  // profile "your CV was removed" banner. Cleared back to null on the next
+  // successful upload.
+  cvPurgedAt   DateTime?
+  linkedin     String?
+  github       String?
+  avatar       String?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
   actionCompletions ActionCompletion[]
   savedByEmployees  SavedStudent[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,14 +47,15 @@ model Student {
   // tracking table if that gap needs closing; until then the GC job is the
   // only thing keeping storage in sync with these columns.
   cv           String?
-  // Set on every successful CV upload, cleared back to null on purge -
-  // updatedAt isn't CV-specific (bumped by any profile edit), so the
-  // twice-yearly retention purge (#286) needs its own clock to tell which
-  // CVs are genuinely older than 6 months.
+  // Set on every successful CV upload - updatedAt isn't CV-specific (bumped
+  // by any profile edit), so the twice-yearly retention purge (#286) needs
+  // its own clock to tell which CVs are genuinely older than 6 months. Not
+  // modified by the purge itself: it stays as the last-upload timestamp
+  // even after `cv` is cleared (see cvPurgedAt below).
   cvUploadedAt DateTime?
   // Stamped by the retention purge when it nulls out `cv`; drives the
   // profile "your CV was removed" banner. Cleared back to null on the next
-  // successful upload.
+  // successful upload, which also refreshes cvUploadedAt above.
   cvPurgedAt   DateTime?
   linkedin     String?
   github       String?

--- a/src/application/dto/studentDto.ts
+++ b/src/application/dto/studentDto.ts
@@ -8,6 +8,9 @@ export interface StudentDto {
   bio: string | null;
   year: string;
   cv: string | null;
+  // Non-null once the twice-yearly retention purge (#286) has cleared `cv` -
+  // drives the profile "your CV was removed" banner.
+  cvPurgedAt: string | null;
   linkedin: string | null;
   github: string | null;
   avatar: string | null;
@@ -25,6 +28,7 @@ interface StudentSummaryEntity {
   bio: string | null;
   year: StudentYear;
   cv: string | null;
+  cvPurgedAt: Date | null;
   linkedin: string | null;
   github: string | null;
   avatar: string | null;
@@ -48,6 +52,7 @@ export const toStudentSummaryDto = (
   bio: student.bio,
   year: studentYearLabel(student.year),
   cv: student.cv,
+  cvPurgedAt: student.cvPurgedAt?.toISOString() ?? null,
   linkedin: student.linkedin,
   github: student.github,
   avatar: student.avatar,

--- a/src/application/repositories/studentRepository.ts
+++ b/src/application/repositories/studentRepository.ts
@@ -68,7 +68,17 @@ export const updateStudentMedia = (
   id: string,
   data: { avatar?: string | null; cv?: string | null },
   db: DbClient = prisma
-) => db.student.update({ where: { id }, data });
+) =>
+  db.student.update({
+    where: { id },
+    data: {
+      ...data,
+      // A fresh cv upload restarts its retention window and un-purges the
+      // profile banner; an omitted or explicitly null cv (no upload at
+      // signup) leaves cvUploadedAt/cvPurgedAt untouched.
+      ...(data.cv ? { cvUploadedAt: new Date(), cvPurgedAt: null } : {}),
+    },
+  });
 
 export const updateStudentAvatar = (code: string, avatar: string) =>
   prisma.student.update({ where: { code }, data: { avatar } });
@@ -77,7 +87,11 @@ export const updateStudentCv = (
   code: string,
   cv: string,
   db: DbClient = prisma
-) => db.student.update({ where: { code }, data: { cv } });
+) =>
+  db.student.update({
+    where: { code },
+    data: { cv, cvUploadedAt: new Date(), cvPurgedAt: null },
+  });
 
 export const countStudents = () =>
   prisma.student.count({ where: { user: { AND: [{ role: "STUDENT" }] } } });

--- a/src/components/Profile/ProfileSectionContainer/index.tsx
+++ b/src/components/Profile/ProfileSectionContainer/index.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import {
+  FiAlertTriangle,
   FiChevronRight,
   FiFileText,
   FiGrid,
@@ -235,6 +236,21 @@ const ProfileSectionContainer: React.FC<ProfileSectionContainerProps> = ({
         >
           {student.user.email}
         </p>
+        {student.cvPurgedAt && (
+          <div
+            className="mb-6 flex items-center gap-3 px-4 py-3 text-sm text-white"
+            style={{
+              border: "1px solid #ED8326",
+              backgroundColor: "rgba(237,131,38,0.1)",
+            }}
+          >
+            <FiAlertTriangle className="h-5 w-5 shrink-0 text-[#ED8326]" />
+            <span>
+              O teu CV foi removido após o período de retenção. Envia um novo em
+              Definições.
+            </span>
+          </div>
+        )}
         {/*
         <p className="p-2 text-center text-white">
           O teu perfil já foi gravado{" "}

--- a/supabase/cv-retention-purge-enable.sql
+++ b/supabase/cv-retention-purge-enable.sql
@@ -1,0 +1,15 @@
+-- Run manually only after reviewing the dry-run result from
+-- cv-retention-purge.sql. This enables irreversible clearing of expired
+-- Student.cv references at 02:00 UTC on May 1 and Nov 1 each year.
+--
+-- 02:00 UTC is deliberately one hour ahead of storage-gc-enable.sql's daily
+-- 03:00 UTC run, so the storage object this purge just orphaned is picked
+-- up and deleted the same day instead of waiting on its own cadence -
+-- addressing #286's "confirm the GC job runs soon enough after Nov 1/May 1"
+-- step without adding a second trigger path.
+
+select cron.schedule(
+  'cv-retention-purge',
+  '0 2 1 5,11 *',
+  $job$select public.purge_expired_student_cvs();$job$
+);

--- a/supabase/cv-retention-purge.sql
+++ b/supabase/cv-retention-purge.sql
@@ -18,13 +18,20 @@
 -- This installer does not enable the purge. Its final query is a required
 -- dry run; inspect every returned row before running
 -- cv-retention-purge-enable.sql.
+--
+-- cvUploadedAt/cvPurgedAt are Prisma DateTime columns, which map to
+-- "timestamp without time zone" (Prisma normalizes to UTC before writing,
+-- there's no zone stored). Comparisons/writes below use
+-- `now() at time zone 'utc'` rather than bare `now()` (timestamptz) to
+-- avoid an implicit, session-timezone-dependent cast against those naive
+-- columns.
 
 create or replace function public.cv_retention_purge_candidates()
 returns table (
   id uuid,
   code text,
   cv text,
-  "cvUploadedAt" timestamptz
+  "cvUploadedAt" timestamp
 )
 language sql
 stable
@@ -34,7 +41,7 @@ as $$
   select students.id, students.code, students.cv, students."cvUploadedAt"
   from public."Student" as students
   where students.cv is not null
-    and students."cvUploadedAt" < now() - interval '6 months'
+    and students."cvUploadedAt" < (now() at time zone 'utc') - interval '6 months'
   order by students."cvUploadedAt"
 $$;
 
@@ -54,7 +61,7 @@ begin
   )
   update public."Student" as students
   set cv = null,
-      "cvPurgedAt" = now()
+      "cvPurgedAt" = (now() at time zone 'utc')
   from expired
   where students.id = expired.id;
 

--- a/supabase/cv-retention-purge.sql
+++ b/supabase/cv-retention-purge.sql
@@ -1,0 +1,69 @@
+-- Run manually in the hosted Supabase SQL editor after Student.cvUploadedAt/
+-- cvPurgedAt exist (see prisma/migrations/20260809105934_add_student_cv_retention).
+--
+-- Twice-yearly retention purge for student CVs (#286): the event always
+-- falls in November, so a calendar-fixed schedule (Nov 1 + May 1) resolves
+-- the per-edition-vs-per-student clock question without inventing a new
+-- "edition boundary" concept - neither is needed. cvUploadedAt (not
+-- updatedAt, which any profile edit bumps) is what makes a fixed schedule
+-- work: it's the CV-specific timestamp that tells a run which CVs are
+-- genuinely older than 6 months.
+--
+-- This job only clears the DB reference (cv = NULL, cvPurgedAt = now()) on
+-- Student - it does not touch storage.objects itself. The existing
+-- orphaned-file GC job (storage-gc.sql) treats the newly-unreferenced
+-- object as a normal orphan and deletes the bytes on its next run; see
+-- cv-retention-purge-enable.sql for how the two schedules line up.
+--
+-- This installer does not enable the purge. Its final query is a required
+-- dry run; inspect every returned row before running
+-- cv-retention-purge-enable.sql.
+
+create or replace function public.cv_retention_purge_candidates()
+returns table (
+  id uuid,
+  code text,
+  cv text,
+  "cvUploadedAt" timestamptz
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select students.id, students.code, students.cv, students."cvUploadedAt"
+  from public."Student" as students
+  where students.cv is not null
+    and students."cvUploadedAt" < now() - interval '6 months'
+  order by students."cvUploadedAt"
+$$;
+
+revoke all on function public.cv_retention_purge_candidates() from public;
+
+create or replace function public.purge_expired_student_cvs()
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  purged_count integer;
+begin
+  with expired as (
+    select id from public.cv_retention_purge_candidates()
+  )
+  update public."Student" as students
+  set cv = null,
+      "cvPurgedAt" = now()
+  from expired
+  where students.id = expired.id;
+
+  get diagnostics purged_count = row_count;
+  return purged_count;
+end;
+$$;
+
+revoke all on function public.purge_expired_student_cvs() from public;
+
+-- Required non-destructive dry run. Review every row before enabling the job.
+select * from public.cv_retention_purge_candidates();


### PR DESCRIPTION
## Summary

- migration: add `Student.cvUploadedAt`/`cvPurgedAt` (`updatedAt` isn't CV-specific — any profile edit bumps it — so the purge needs its own clock)
- `updateStudentCv`/`updateStudentMedia` now stamp `cvUploadedAt = now()` and clear `cvPurgedAt` on every successful CV upload (initial signup upload and later profile replace, the only two write paths for `Student.cv`)
- `supabase/cv-retention-purge.sql` + `cv-retention-purge-enable.sql`: a twice-yearly `pg_cron` job (May 1 + Nov 1, 02:00 UTC), mirroring `storage-gc.sql`'s dry-run-then-enable pattern, that clears `cv`/stamps `cvPurgedAt` for every `Student` with `cvUploadedAt` older than 6 months. Fixed calendar schedule (the event always falls in November) avoids inventing a per-edition clock. It only touches the DB reference — the existing orphaned-file GC job picks up the now-unreferenced storage object
- scheduled 02:00 UTC, one hour ahead of the GC job's daily 03:00 UTC run, so the newly-orphaned object is deleted the same day instead of waiting on its own cadence — resolves the issue's "confirm the GC job runs soon enough" step without a second trigger path
- `StudentDto`/`StudentSummaryDto` gain `cvPurgedAt`; `ProfileSectionContainer` renders a banner in the profile header whenever it's set, telling the student their CV was removed and where to upload a new one
- README: document the new job alongside the existing GC section

Closes #286

## Verification

- `pnpm test` (263 passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors)
- `pnpm build` (production build succeeds, including `/student/[...data]`)
- Migration and both SQL functions verified end-to-end against a throwaway `postgres:16-alpine` container (not Supabase — no local Supabase stack available in this worktree): applied all 12 migrations cleanly via `prisma migrate deploy`, confirmed `prisma migrate status` reports no drift, then seeded an expired CV / a fresh CV / a no-CV student and ran the dry-run and purge functions directly — only the expired row was purged, the fresh and no-CV rows were untouched, and a second purge run was a correct no-op

Not exercised: the profile banner against a real authenticated session (this worktree has no configured Supabase Auth environment). `pnpm build` compiles and type-checks the page/component correctly, and the conditional render (`{student.cvPurgedAt && (...)}`) is a small, direct JSX check, but I did not visually confirm it in a running browser session.