### PR TITLE
ci: automate release publishing and bootstrap v2

### DIFF
--- a/.github/workflows/release-bootstrap.yml
+++ b/.github/workflows/release-bootstrap.yml
@@ -1,0 +1,59 @@
+name: Release Bootstrap
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/release-bootstrap.yml
+  workflow_dispatch: {}
+
+jobs:
+  bootstrap-v2:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      BOOTSTRAP_SHA: a9e2e24264d9cb49242b60e6b3606e6673e792ff
+    steps:
+      - name: Create release labels
+        run: |
+          gh label create release:major --color B60205 --description "Next merge to main creates a new major release" --force
+          gh label create release:minor --color 0E8A16 --description "Next merge to main creates a new minor release" --force
+          gh label create release:patch --color 1D76DB --description "Next merge to main creates a new patch release" --force
+
+      - name: Publish Fallstack v2 baseline
+        run: |
+          set -euo pipefail
+
+          if gh release view v2.0.0 >/dev/null 2>&1; then
+            echo "v2.0.0 already exists; bootstrap is complete."
+            exit 0
+          fi
+
+          cat > /tmp/release-notes.md <<EOF
+          # Fallstack v2
+
+          Fallstack v2 standardizes the project on the semantic-version release flow used by the NEI platforms.
+
+          ## Baseline
+
+          The code in this release is intentionally identical to the existing v1.1.0 / Fallstack 2026 maintenance baseline. There are no hidden feature changes between those two tags; v2.0.0 is the new versioning baseline from which future automated releases are calculated.
+
+          The historical edition markers remain available: 2025-edition, 2026-edition and v1.1.0.
+
+          ## Current platform
+
+          This baseline contains the Fallstack 2026 application with its admin backoffice, AuthNEI sign-in, student/company workflows, sponsor and schedule management, observability and security hardening, Docker/Coolify deployment, and the existing CI/test gates.
+
+          Open stabilization work is not part of this v2 baseline. Future PRs into main select exactly one semantic-version bump using release:major, release:minor or release:patch.
+          EOF
+
+          gh release create v2.0.0 \
+            --target "$BOOTSTRAP_SHA" \
+            --title "Fallstack v2" \
+            --notes-file /tmp/release-notes.md \
+            --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,22 +4,10 @@ on:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, labeled, unlabeled, closed]
-  push:
-    branches: [main]
-    paths:
-      - ".github/workflows/release.yml"
-
-concurrency:
-  group: release-main
-  cancel-in-progress: false
-
-env:
-  PRODUCT_NAME: Fallstack
-  BOOTSTRAP_SHA: a9e2e24264d9cb49242b60e6b3606e6673e792ff
 
 jobs:
   validate-release-label:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.head.ref != 'agent/release-automation-v2-bootstrap'
+    if: github.event.action != 'closed' && github.event.pull_request.head.ref != 'agent/release-automation-v2-bootstrap'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,62 +26,8 @@ jobs:
               core.setFailed(`PRs into main must have exactly one release label: ${releaseLabels.join(", ")}. Found: ${selected.join(", ") || "none"}.`);
             }
 
-  bootstrap-v2:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-    steps:
-      - name: Publish v2 baseline and create release labels
-        uses: actions/github-script@v9
-        env:
-          BOOTSTRAP_SHA: ${{ env.BOOTSTRAP_SHA }}
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const bootstrapSha = process.env.BOOTSTRAP_SHA;
-            const v2Tag = "v2.0.0";
-            const refs = await github.paginate(github.rest.git.listMatchingRefs, { owner, repo, ref: "tags/", per_page: 100 });
-            const releaseLabels = [
-              { name: "release:major", color: "b60205", description: "Next merge to main creates a new major release" },
-              { name: "release:minor", color: "0e8a16", description: "Next merge to main creates a new minor release" },
-              { name: "release:patch", color: "1d76db", description: "Next merge to main creates a new patch release" },
-            ];
-            for (const label of releaseLabels) {
-              try { await github.rest.issues.createLabel({ owner, repo, ...label }); }
-              catch (error) { if (error.status !== 422) throw error; }
-            }
-            if (refs.some((ref) => ref.ref === `refs/tags/${v2Tag}`)) {
-              core.info(`${v2Tag} already exists; bootstrap is complete.`);
-              return;
-            }
-            await github.rest.git.createRef({ owner, repo, ref: `refs/tags/${v2Tag}`, sha: bootstrapSha });
-            const body = `# Fallstack v2
-
-Fallstack v2 standardizes the project on the same semantic-version release flow used by the other NEI platforms.
-
-## Baseline
-
-The code in this release is intentionally identical to the existing \`v1.1.0\` / Fallstack 2026 maintenance baseline. There are no hidden feature changes between those two tags; \`v2.0.0\` is the new versioning baseline from which future automated releases are calculated.
-
-The existing historical edition markers are preserved:
-
-- \`2025-edition\`
-- \`2026-edition\`
-- \`v1.1.0\`
-
-## Current platform
-
-The baseline includes the Fallstack 2026 application with the admin backoffice, AuthNEI sign-in, company/student workflows, sponsor and schedule management, observability, security hardening, Docker/Coolify deployment and the existing CI/test gates documented by the project.
-
-## Future releases
-
-Open stabilization work is not part of this v2 baseline. From now on, PRs into \`main\` select exactly one semantic-version bump using \`release:major\`, \`release:minor\` or \`release:patch\`, and merged PRs automatically create the tag and GitHub Release.`;
-            await github.rest.repos.createRelease({ owner, repo, tag_name: v2Tag, target_commitish: bootstrapSha, name: "Fallstack v2", body, draft: false, prerelease: false, make_latest: "true" });
-
   publish-release:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.head.ref != 'agent/release-automation-v2-bootstrap'
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.head.ref != 'agent/release-automation-v2-bootstrap'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -106,10 +40,10 @@ Open stabilization work is not part of this v2 baseline. From now on, PRs into \
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-          PRODUCT_NAME: ${{ env.PRODUCT_NAME }}
         with:
           script: |
             const { owner, repo } = context.repo;
+            const productName = "Fallstack";
             const releaseLabels = ["release:major", "release:minor", "release:patch"];
             const labels = JSON.parse(process.env.LABELS_JSON || "[]");
             const selected = labels.filter((label) => releaseLabels.includes(label));
@@ -132,9 +66,4 @@ Open stabilization work is not part of this v2 baseline. From now on, PRs into \
             const mergeSha = process.env.MERGE_SHA;
             const notes = await github.rest.repos.generateReleaseNotes({ owner, repo, tag_name: nextTag, target_commitish: mergeSha, previous_tag_name: latest.name });
             await github.rest.git.createRef({ owner, repo, ref: `refs/tags/${nextTag}`, sha: mergeSha });
-            await github.rest.repos.createRelease({
-              owner, repo, tag_name: nextTag, target_commitish: mergeSha,
-              name: `${process.env.PRODUCT_NAME} ${nextTag}`,
-              body: `Released automatically from PR #${process.env.PR_NUMBER}: ${process.env.PR_TITLE}.\n\n${notes.data.body}`,
-              draft: false, prerelease: false, make_latest: "true",
-            });
+            await github.rest.repos.createRelease({ owner, repo, tag_name: nextTag, target_commitish: mergeSha, name: `${productName} ${nextTag}`, body: `Released automatically from PR #${process.env.PR_NUMBER}: ${process.env.PR_TITLE}.\n\n${notes.data.body}`, draft: false, prerelease: false, make_latest: "true" });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,140 @@
+name: Release
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled, closed]
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/release.yml"
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+env:
+  PRODUCT_NAME: Fallstack
+  BOOTSTRAP_SHA: a9e2e24264d9cb49242b60e6b3606e6673e792ff
+
+jobs:
+  validate-release-label:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.head.ref != 'agent/release-automation-v2-bootstrap'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Require exactly one release label
+        uses: actions/github-script@v9
+        env:
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        with:
+          script: |
+            const releaseLabels = ["release:major", "release:minor", "release:patch"];
+            const labels = JSON.parse(process.env.LABELS_JSON || "[]");
+            const selected = labels.filter((label) => releaseLabels.includes(label));
+            if (selected.length !== 1) {
+              core.setFailed(`PRs into main must have exactly one release label: ${releaseLabels.join(", ")}. Found: ${selected.join(", ") || "none"}.`);
+            }
+
+  bootstrap-v2:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Publish v2 baseline and create release labels
+        uses: actions/github-script@v9
+        env:
+          BOOTSTRAP_SHA: ${{ env.BOOTSTRAP_SHA }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const bootstrapSha = process.env.BOOTSTRAP_SHA;
+            const v2Tag = "v2.0.0";
+            const refs = await github.paginate(github.rest.git.listMatchingRefs, { owner, repo, ref: "tags/", per_page: 100 });
+            const releaseLabels = [
+              { name: "release:major", color: "b60205", description: "Next merge to main creates a new major release" },
+              { name: "release:minor", color: "0e8a16", description: "Next merge to main creates a new minor release" },
+              { name: "release:patch", color: "1d76db", description: "Next merge to main creates a new patch release" },
+            ];
+            for (const label of releaseLabels) {
+              try { await github.rest.issues.createLabel({ owner, repo, ...label }); }
+              catch (error) { if (error.status !== 422) throw error; }
+            }
+            if (refs.some((ref) => ref.ref === `refs/tags/${v2Tag}`)) {
+              core.info(`${v2Tag} already exists; bootstrap is complete.`);
+              return;
+            }
+            await github.rest.git.createRef({ owner, repo, ref: `refs/tags/${v2Tag}`, sha: bootstrapSha });
+            const body = `# Fallstack v2
+
+Fallstack v2 standardizes the project on the same semantic-version release flow used by the other NEI platforms.
+
+## Baseline
+
+The code in this release is intentionally identical to the existing \`v1.1.0\` / Fallstack 2026 maintenance baseline. There are no hidden feature changes between those two tags; \`v2.0.0\` is the new versioning baseline from which future automated releases are calculated.
+
+The existing historical edition markers are preserved:
+
+- \`2025-edition\`
+- \`2026-edition\`
+- \`v1.1.0\`
+
+## Current platform
+
+The baseline includes the Fallstack 2026 application with the admin backoffice, AuthNEI sign-in, company/student workflows, sponsor and schedule management, observability, security hardening, Docker/Coolify deployment and the existing CI/test gates documented by the project.
+
+## Future releases
+
+Open stabilization work is not part of this v2 baseline. From now on, PRs into \`main\` select exactly one semantic-version bump using \`release:major\`, \`release:minor\` or \`release:patch\`, and merged PRs automatically create the tag and GitHub Release.`;
+            await github.rest.repos.createRelease({ owner, repo, tag_name: v2Tag, target_commitish: bootstrapSha, name: "Fallstack v2", body, draft: false, prerelease: false, make_latest: "true" });
+
+  publish-release:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.head.ref != 'agent/release-automation-v2-bootstrap'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Tag merged main PR and publish release
+        uses: actions/github-script@v9
+        env:
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PRODUCT_NAME: ${{ env.PRODUCT_NAME }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const releaseLabels = ["release:major", "release:minor", "release:patch"];
+            const labels = JSON.parse(process.env.LABELS_JSON || "[]");
+            const selected = labels.filter((label) => releaseLabels.includes(label));
+            if (selected.length !== 1) {
+              core.setFailed(`Merged PR must have exactly one release label. Found: ${selected.join(", ") || "none"}.`);
+              return;
+            }
+            const refs = await github.paginate(github.rest.git.listMatchingRefs, { owner, repo, ref: "tags/v", per_page: 100 });
+            const versions = refs.map((ref) => ref.ref.replace("refs/tags/", "")).map((name) => {
+              const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(name);
+              return match ? { name, major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) } : null;
+            }).filter(Boolean).sort((a, b) => a.major - b.major || a.minor - b.minor || a.patch - b.patch);
+            if (versions.length === 0) { core.setFailed("No semantic-version release tag exists to bump from."); return; }
+            const latest = versions.at(-1);
+            let { major, minor, patch } = latest;
+            if (selected[0] === "release:major") { major += 1; minor = 0; patch = 0; }
+            else if (selected[0] === "release:minor") { minor += 1; patch = 0; }
+            else patch += 1;
+            const nextTag = `v${major}.${minor}.${patch}`;
+            const mergeSha = process.env.MERGE_SHA;
+            const notes = await github.rest.repos.generateReleaseNotes({ owner, repo, tag_name: nextTag, target_commitish: mergeSha, previous_tag_name: latest.name });
+            await github.rest.git.createRef({ owner, repo, ref: `refs/tags/${nextTag}`, sha: mergeSha });
+            await github.rest.repos.createRelease({
+              owner, repo, tag_name: nextTag, target_commitish: mergeSha,
+              name: `${process.env.PRODUCT_NAME} ${nextTag}`,
+              body: `Released automatically from PR #${process.env.PR_NUMBER}: ${process.env.PR_TITLE}.\n\n${notes.data.body}`,
+              draft: false, prerelease: false, make_latest: "true",
+            });


### PR DESCRIPTION
## Summary

- establish `v2.0.0` as the new semantic-version baseline for Fallstack
- preserve the existing `2025-edition`, `2026-edition`, and `v1.1.0` historical tags/releases
- create `release:major`, `release:minor`, and `release:patch` labels
- require future PRs into `main` to select exactly one release bump
- automatically tag merged PRs into `main` and publish GitHub Releases with generated release notes

## Bootstrap behavior

`v2.0.0` is pinned to the current `main` SHA `a9e2e24264d9cb49242b60e6b3606e6673e792ff`.

That SHA is identical to the existing `v1.1.0`, so this is intentionally a versioning-baseline change rather than a claim of new code between v1.1.0 and v2.0.0.

## Future releases

PRs targeting `main` must carry exactly one of:

- `release:major`
- `release:minor`
- `release:patch`

When merged, the workflow calculates the next SemVer tag and publishes the GitHub Release automatically.