### PR TITLE
ci: centralize dev secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,26 +88,4 @@ jobs:
     name: Secret scan
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout full history
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Install verified Gitleaks binary
-        env:
-          GITLEAKS_VERSION: 8.30.1
-        run: |
-          asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
-          curl --fail --silent --show-error --location --output "$asset" "$base/$asset"
-          curl --fail --silent --show-error --location --output checksums.txt "$base/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
-          grep " $asset$" checksums.txt | sha256sum --check --strict
-          tar -xzf "$asset" gitleaks
-
-      - name: Scan pull-request commits
-        if: github.event_name == 'pull_request'
-        run: ./gitleaks git --redact --no-banner --log-opts="${{ github.event.pull_request.base.sha }}..${{ github.sha }}" .
-
-      - name: Scan pushed commit
-        if: github.event_name != 'pull_request'
-        run: ./gitleaks git --redact --no-banner --log-opts=-1 .
+      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/secret-scan@master

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,24 +1,11 @@
 name: Security
 
 on:
-  push:
-    branches: [dev, main]
   pull_request:
     branches: [dev, main]
-  schedule:
-    - cron: "23 4 * * 1"
   workflow_dispatch:
 
 jobs:
-  codeql:
-    if: github.event.repository.private == false
-    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/codeql.yml@master
-    permissions:
-      security-events: write
-      packages: read
-      actions: read
-      contents: read
-
   dependency-review:
     if: github.event_name == 'pull_request' && github.event.repository.private == false
     uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/dependency-review.yml@master

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Security
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+  schedule:
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+
+jobs:
+  codeql:
+    if: github.event.repository.private == false
+    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/codeql.yml@master
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+  dependency-review:
+    if: github.event_name == 'pull_request' && github.event.repository.private == false
+    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/dependency-review.yml@master
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary

Replace the duplicated Gitleaks implementation in Fallstack `dev` CI with the organization-standard shared action.

- keep tests, typecheck, lint, production build, Prisma validation and Docker checks unchanged
- preserve the `Secret scan` job/check name
- keep the existing default CODEOWNERS on `dev`

No application/runtime changes; the stabilization PR remains independently reviewable.