### PR TITLE
ci: prefer CodeQL Default Setup on main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,24 +1,11 @@
 name: Security
 
 on:
-  push:
-    branches: [dev, main]
   pull_request:
     branches: [dev, main]
-  schedule:
-    - cron: "23 4 * * 1"
   workflow_dispatch:
 
 jobs:
-  codeql:
-    if: github.event.repository.private == false
-    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/codeql.yml@master
-    permissions:
-      security-events: write
-      packages: read
-      actions: read
-      contents: read
-
   dependency-review:
     if: github.event_name == 'pull_request' && github.event.repository.private == false
     uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/dependency-review.yml@master


### PR DESCRIPTION
## Summary

Use GitHub CodeQL Default Setup after Fallstack is public and keep the local security workflow focused on shared dependency review.

Default Setup and advanced CodeQL Actions are mutually exclusive. Dependency review remains skipped while private and activates automatically after publication.

No runtime changes and independent of the open stabilization PR.