### PR TITLE
ci: target Dependabot updates to dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,55 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  # Para dependências npm (Next.js incluído)
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
+    target-branch: dev
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps)"
-    ignore:
-      - dependency-name: "next"
-        versions: ["13.x"]
+      prefix: chore(deps)
     labels:
-      - "dependencies"
-      - "automated"
+      - dependencies
+      - automated
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore(ci)
+
+  - package-ecosystem: docker
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore(docker)


### PR DESCRIPTION
## Summary

Fix the Dependabot configuration GitHub actually loads from Fallstack's default `main` branch.

- target npm, GitHub Actions and Docker updates to `dev`
- group routine dependency updates
- allow patch/minor updates automatically and leave major upgrades for dedicated migration work
- keep the existing `dependencies`/`automated` labels for npm updates

This is repository automation only and is independent of the open platform-stabilization PR.