### PR TITLE
ci: audit repository before publication

### DIFF
--- a/.github/workflows/publication-audit.yml
+++ b/.github/workflows/publication-audit.yml
@@ -38,6 +38,14 @@ jobs:
           status=$?
           set -e
           if [ -s "$RUNNER_TEMP/gitleaks.json" ]; then
-            jq -r '.[] | "rule=\(.RuleID) file=\(.File) commit=\(.Commit) line=\(.StartLine)"' "$RUNNER_TEMP/gitleaks.json"
+            while IFS= read -r row; do
+              rule=$(printf '%s' "$row" | base64 -d | jq -r '.RuleID')
+              file=$(printf '%s' "$row" | base64 -d | jq -r '.File')
+              commit=$(printf '%s' "$row" | base64 -d | jq -r '.Commit')
+              line=$(printf '%s' "$row" | base64 -d | jq -r '.StartLine')
+              raw=$(git show "$commit:$file" | sed -n "${line}p")
+              context=$(printf '%s' "$raw" | sed -E 's/([=:]).*/\1 [REDACTED]/')
+              printf 'rule=%s file=%s commit=%s line=%s context=%s\n' "$rule" "$file" "$commit" "$line" "$context"
+            done < <(jq -r '.[] | @base64' "$RUNNER_TEMP/gitleaks.json")
           fi
           exit "$status"

--- a/.github/workflows/publication-audit.yml
+++ b/.github/workflows/publication-audit.yml
@@ -1,0 +1,18 @@
+name: Publication audit
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  full-history-secret-scan:
+    name: Full-history secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/secret-scan@master
+        with:
+          full-history: "true"

--- a/.github/workflows/publication-audit.yml
+++ b/.github/workflows/publication-audit.yml
@@ -13,6 +13,31 @@ jobs:
     name: Full-history secret scan
     runs-on: ubuntu-latest
     steps:
-      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/secret-scan@master
+      - name: Checkout full history
+        uses: actions/checkout@v5
         with:
-          full-history: "true"
+          fetch-depth: 0
+
+      - name: Install verified Gitleaks
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=8.30.1
+          asset="gitleaks_${version}_linux_x64.tar.gz"
+          base="https://github.com/gitleaks/gitleaks/releases/download/v${version}"
+          curl -fsSL -o "$RUNNER_TEMP/$asset" "$base/$asset"
+          curl -fsSL -o "$RUNNER_TEMP/checksums.txt" "$base/gitleaks_${version}_checksums.txt"
+          (cd "$RUNNER_TEMP" && grep " $asset$" checksums.txt | sha256sum --check --strict)
+          tar -xzf "$RUNNER_TEMP/$asset" -C "$RUNNER_TEMP" gitleaks
+
+      - name: Scan full history and print sanitized metadata
+        shell: bash
+        run: |
+          set +e
+          "$RUNNER_TEMP/gitleaks" git --redact --no-banner --report-format json --report-path "$RUNNER_TEMP/gitleaks.json" .
+          status=$?
+          set -e
+          if [ -s "$RUNNER_TEMP/gitleaks.json" ]; then
+            jq -r '.[] | "rule=\(.RuleID) file=\(.File) commit=\(.Commit) line=\(.StartLine)"' "$RUNNER_TEMP/gitleaks.json"
+          fi
+          exit "$status"

--- a/.github/workflows/publication-audit.yml
+++ b/.github/workflows/publication-audit.yml
@@ -49,3 +49,32 @@ jobs:
             done < <(jq -r '.[] | @base64' "$RUNNER_TEMP/gitleaks.json")
           fi
           exit "$status"
+
+      - name: Classify historical Supabase JWTs without exposing values
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          commit=a9a241ea094a1412d4e136d7752c48fc57ac847c
+          content=$(git show "$commit:.env.example")
+          key_a=$(printf '%s\n' "$content" | sed -n '12p' | cut -d= -f2- | tr -d '"')
+          key_b=$(printf '%s\n' "$content" | sed -n '14p' | cut -d= -f2- | tr -d '"')
+
+          jwt_role() {
+            local token="$1"
+            local payload
+            payload=$(printf '%s' "$token" | cut -d. -f2 | tr '_-' '/+')
+            case $((${#payload} % 4)) in
+              2) payload="${payload}==" ;;
+              3) payload="${payload}=" ;;
+            esac
+            printf '%s' "$payload" | base64 -d 2>/dev/null | jq -r '.role // "unknown"'
+          }
+
+          printf 'SUPABASE_KEY role=%s\n' "$(jwt_role "$key_a")"
+          printf 'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY role=%s\n' "$(jwt_role "$key_b")"
+          if [ "$key_a" = "$key_b" ]; then
+            echo 'historical_supabase_values_equal=true'
+          else
+            echo 'historical_supabase_values_equal=false'
+          fi


### PR DESCRIPTION
## Publication-readiness audit result

Closed without merge after a full-history Gitleaks audit.

Findings:
- two `generic-api-key` matches in historical release-workflow prose are false positives;
- historical `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` decodes to role `anon` and is not a privileged secret;
- historical `SUPABASE_KEY` decodes to role `service_role`.

**Publication blocker:** confirm that the historical Supabase `service_role` key from commit `a9a241ea094a1412d4e136d7752c48fc57ac847c` has been revoked/rotated before making this repository public. Rewriting Git history is not a substitute for rotation and is unnecessary once the key is revoked.