### PR TITLE
chore(deploy): validate Coolify environment variables

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -6,8 +6,9 @@ services:
       target: migrator
     container_name: fallstack-migrate
     restart: "no"
-    env_file:
-      - ./.env # adjust to .env.production if you want production settings
+    environment:
+      DATABASE_URL: ${DATABASE_URL:?Configure DATABASE_URL in Coolify}
+      DIRECT_URL: ${DIRECT_URL:?Configure DIRECT_URL in Coolify}
 
   web:
     build:
@@ -18,17 +19,15 @@ services:
         SENTRY_URL: ${SENTRY_URL:-}
         SENTRY_ORG: ${SENTRY_ORG:-}
         SENTRY_PROJECT: ${SENTRY_PROJECT:-}
-        NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL:-}
-        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:-}
-        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-}
+        NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL:?Configure NEXT_PUBLIC_SUPABASE_URL in Coolify}
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:?Configure NEXT_PUBLIC_SUPABASE_ANON_KEY in Coolify}
+        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?Configure NEXT_PUBLIC_BASE_URL in Coolify}
         NEXT_PUBLIC_LOGS_DASHBOARD_URL: ${NEXT_PUBLIC_LOGS_DASHBOARD_URL:-}
     container_name: fallstack-app
     restart: unless-stopped
     depends_on:
       migrate:
         condition: service_completed_successfully
-    env_file:
-      - ./.env # adjust to .env.production if you want production settings
     ports:
       - "4000:4000" # Host:Container matches Dockerfile EXPOSE 4000
     # Uncomment if you want live code mounting during development (only works with dev build)
@@ -38,3 +37,13 @@ services:
     environment:
       PORT: 4000
       HOSTNAME: 0.0.0.0
+      DATABASE_URL: ${DATABASE_URL:?Configure DATABASE_URL in Coolify}
+      DIRECT_URL: ${DIRECT_URL:?Configure DIRECT_URL in Coolify}
+      JWT_SECRET: ${JWT_SECRET:?Configure JWT_SECRET in Coolify}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:?Configure SUPABASE_SERVICE_ROLE_KEY in Coolify}
+      NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL:?Configure NEXT_PUBLIC_SUPABASE_URL in Coolify}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:?Configure NEXT_PUBLIC_SUPABASE_ANON_KEY in Coolify}
+      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?Configure NEXT_PUBLIC_BASE_URL in Coolify}
+      NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
+      NEXT_PUBLIC_LOGS_DASHBOARD_URL: ${NEXT_PUBLIC_LOGS_DASHBOARD_URL:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/tests/e2e/dockerBuildArgs.test.ts
+++ b/tests/e2e/dockerBuildArgs.test.ts
@@ -104,10 +104,11 @@ function extractComposeServiceEnvironment(service: string): string {
 }
 
 function expectRequiredComposeVariable(block: string, name: string) {
+  const requiredExpansion = "${" + name + ":?";
   expect(
     block,
     `docker-compose.app.yml must mark ${name} as required with Compose's :? expansion`
-  ).toMatch(new RegExp(`^\\s*${name}: \\${\\{${name}:\\?`, "m"));
+  ).toContain(`${name}: ${requiredExpansion}`);
 }
 
 test("every NEXT_PUBLIC_* var declared in env.client.ts is wired through the Dockerfile's app-builder ARG/ENV pair", () => {

--- a/tests/e2e/dockerBuildArgs.test.ts
+++ b/tests/e2e/dockerBuildArgs.test.ts
@@ -47,6 +47,10 @@ function extractDockerfileAppBuilderStage(): string {
   return dockerfile.slice(start, nextStage === -1 ? undefined : nextStage);
 }
 
+function readCompose(): string {
+  return readFileSync(path.join(ROOT, "docker-compose.app.yml"), "utf-8");
+}
+
 function sliceIndentedBlock(lines: string[], fromIndex: number): string[] {
   const blockIndent = lines[fromIndex].search(/\S/);
   const blockLines: string[] = [];
@@ -59,24 +63,21 @@ function sliceIndentedBlock(lines: string[], fromIndex: number): string[] {
   return blockLines;
 }
 
-function extractComposeWebBuildArgs(): string {
-  const compose = readFileSync(
-    path.join(ROOT, "docker-compose.app.yml"),
-    "utf-8"
+function extractComposeServiceBlock(service: string): string[] {
+  const lines = readCompose().split("\n");
+  const serviceLineIndex = lines.findIndex(
+    (line) => line.trim() === `${service}:`
   );
-  const lines = compose.split("\n");
-
-  // Anchored to the `web:` service specifically, not just the first
-  // `args:` block anywhere in the file - a sibling service (e.g.
-  // `migrate:`) could grow its own `build.args:` block in the future
-  // without this test noticing it was looking at the wrong one.
-  const webLineIndex = lines.findIndex((line) => line.trim() === "web:");
-  if (webLineIndex === -1) {
+  if (serviceLineIndex === -1) {
     throw new Error(
-      "Couldn't find a top-level `web:` service in docker-compose.app.yml - has it been renamed?"
+      `Couldn't find a top-level \`${service}:\` service in docker-compose.app.yml`
     );
   }
-  const webBlockLines = sliceIndentedBlock(lines, webLineIndex);
+  return sliceIndentedBlock(lines, serviceLineIndex);
+}
+
+function extractComposeWebBuildArgs(): string {
+  const webBlockLines = extractComposeServiceBlock("web");
 
   const argsLineIndex = webBlockLines.findIndex(
     (line) => line.trim() === "args:"
@@ -87,6 +88,26 @@ function extractComposeWebBuildArgs(): string {
     );
   }
   return sliceIndentedBlock(webBlockLines, argsLineIndex).join("\n");
+}
+
+function extractComposeServiceEnvironment(service: string): string {
+  const serviceBlockLines = extractComposeServiceBlock(service);
+  const environmentLineIndex = serviceBlockLines.findIndex(
+    (line) => line.trim() === "environment:"
+  );
+  if (environmentLineIndex === -1) {
+    throw new Error(
+      `Couldn't find \`${service}.environment:\` in docker-compose.app.yml`
+    );
+  }
+  return sliceIndentedBlock(serviceBlockLines, environmentLineIndex).join("\n");
+}
+
+function expectRequiredComposeVariable(block: string, name: string) {
+  expect(
+    block,
+    `docker-compose.app.yml must mark ${name} as required with Compose's :? expansion`
+  ).toMatch(new RegExp(`^\\s*${name}: \\${\\{${name}:\\?`, "m"));
 }
 
 test("every NEXT_PUBLIC_* var declared in env.client.ts is wired through the Dockerfile's app-builder ARG/ENV pair", () => {
@@ -116,5 +137,34 @@ test("every NEXT_PUBLIC_* var declared in env.client.ts is passed as a build arg
       webBuildArgs,
       `docker-compose.app.yml's web.build.args is missing "${name}"`
     ).toMatch(new RegExp(`^\\s*${name}:`, "m"));
+  }
+});
+
+test("Coolify compose marks production build and runtime configuration as required", () => {
+  const webBuildArgs = extractComposeWebBuildArgs();
+  for (const name of [
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    "NEXT_PUBLIC_BASE_URL",
+  ]) {
+    expectRequiredComposeVariable(webBuildArgs, name);
+  }
+
+  const migrateEnvironment = extractComposeServiceEnvironment("migrate");
+  for (const name of ["DATABASE_URL", "DIRECT_URL"]) {
+    expectRequiredComposeVariable(migrateEnvironment, name);
+  }
+
+  const webEnvironment = extractComposeServiceEnvironment("web");
+  for (const name of [
+    "DATABASE_URL",
+    "DIRECT_URL",
+    "JWT_SECRET",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    "NEXT_PUBLIC_BASE_URL",
+  ]) {
+    expectRequiredComposeVariable(webEnvironment, name);
   }
 });


### PR DESCRIPTION
## Summary
- remove the runtime dependency on a repository `.env` file from `docker-compose.app.yml`
- declare required database, Supabase and JWT variables explicitly with Compose `:?` validation
- require public Supabase/base URL values at Docker build time instead of allowing empty values
- keep Sentry/log dashboard settings optional with safe defaults
- add regression coverage for required Coolify build/runtime variable wiring

## Why
The app already validates these values in Zod/Prisma, but the Compose file previously allowed missing values and relied on `env_file: ./.env`. That makes Coolify configuration harder to audit and can let a Docker build start with invalid public configuration.

## Coolify variables to fill
- `DATABASE_URL`
- `DIRECT_URL`
- `JWT_SECRET`
- `SUPABASE_SERVICE_ROLE_KEY`
- `NEXT_PUBLIC_SUPABASE_URL`
- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
- `NEXT_PUBLIC_BASE_URL`

Sentry-related variables and `NEXT_PUBLIC_LOGS_DASHBOARD_URL` remain optional.