### PR TITLE
chore(deploy): derive Coolify service URLs

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -6,8 +6,9 @@ services:
       target: migrator
     container_name: fallstack-migrate
     restart: "no"
-    env_file:
-      - ./.env # adjust to .env.production if you want production settings
+    environment:
+      DATABASE_URL: ${DATABASE_URL:?Configure DATABASE_URL in Coolify}
+      DIRECT_URL: ${DIRECT_URL:-${DATABASE_URL:?Configure DATABASE_URL in Coolify}}
 
   web:
     build:
@@ -18,17 +19,15 @@ services:
         SENTRY_URL: ${SENTRY_URL:-}
         SENTRY_ORG: ${SENTRY_ORG:-}
         SENTRY_PROJECT: ${SENTRY_PROJECT:-}
-        NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL:-}
-        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:-}
-        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-}
+        NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL:?Configure NEXT_PUBLIC_SUPABASE_URL in Coolify}
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:?Configure NEXT_PUBLIC_SUPABASE_ANON_KEY in Coolify}
+        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-${SERVICE_URL_WEB:-http://localhost:4000}/api}
         NEXT_PUBLIC_LOGS_DASHBOARD_URL: ${NEXT_PUBLIC_LOGS_DASHBOARD_URL:-}
     container_name: fallstack-app
     restart: unless-stopped
     depends_on:
       migrate:
         condition: service_completed_successfully
-    env_file:
-      - ./.env # adjust to .env.production if you want production settings
     ports:
       - "4000:4000" # Host:Container matches Dockerfile EXPOSE 4000
     # Uncomment if you want live code mounting during development (only works with dev build)
@@ -38,3 +37,13 @@ services:
     environment:
       PORT: 4000
       HOSTNAME: 0.0.0.0
+      DATABASE_URL: ${DATABASE_URL:?Configure DATABASE_URL in Coolify}
+      DIRECT_URL: ${DIRECT_URL:-${DATABASE_URL:?Configure DATABASE_URL in Coolify}}
+      JWT_SECRET: ${JWT_SECRET:?Configure JWT_SECRET in Coolify}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:?Configure SUPABASE_SERVICE_ROLE_KEY in Coolify}
+      NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL:?Configure NEXT_PUBLIC_SUPABASE_URL in Coolify}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:?Configure NEXT_PUBLIC_SUPABASE_ANON_KEY in Coolify}
+      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-${SERVICE_URL_WEB:-http://localhost:4000}/api}
+      NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
+      NEXT_PUBLIC_LOGS_DASHBOARD_URL: ${NEXT_PUBLIC_LOGS_DASHBOARD_URL:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/tests/e2e/dockerBuildArgs.test.ts
+++ b/tests/e2e/dockerBuildArgs.test.ts
@@ -47,6 +47,10 @@ function extractDockerfileAppBuilderStage(): string {
   return dockerfile.slice(start, nextStage === -1 ? undefined : nextStage);
 }
 
+function readCompose(): string {
+  return readFileSync(path.join(ROOT, "docker-compose.app.yml"), "utf-8");
+}
+
 function sliceIndentedBlock(lines: string[], fromIndex: number): string[] {
   const blockIndent = lines[fromIndex].search(/\S/);
   const blockLines: string[] = [];
@@ -59,24 +63,21 @@ function sliceIndentedBlock(lines: string[], fromIndex: number): string[] {
   return blockLines;
 }
 
-function extractComposeWebBuildArgs(): string {
-  const compose = readFileSync(
-    path.join(ROOT, "docker-compose.app.yml"),
-    "utf-8"
+function extractComposeServiceBlock(service: string): string[] {
+  const lines = readCompose().split("\n");
+  const serviceLineIndex = lines.findIndex(
+    (line) => line.trim() === `${service}:`
   );
-  const lines = compose.split("\n");
-
-  // Anchored to the `web:` service specifically, not just the first
-  // `args:` block anywhere in the file - a sibling service (e.g.
-  // `migrate:`) could grow its own `build.args:` block in the future
-  // without this test noticing it was looking at the wrong one.
-  const webLineIndex = lines.findIndex((line) => line.trim() === "web:");
-  if (webLineIndex === -1) {
+  if (serviceLineIndex === -1) {
     throw new Error(
-      "Couldn't find a top-level `web:` service in docker-compose.app.yml - has it been renamed?"
+      `Couldn't find a top-level \`${service}:\` service in docker-compose.app.yml`
     );
   }
-  const webBlockLines = sliceIndentedBlock(lines, webLineIndex);
+  return sliceIndentedBlock(lines, serviceLineIndex);
+}
+
+function extractComposeWebBuildArgs(): string {
+  const webBlockLines = extractComposeServiceBlock("web");
 
   const argsLineIndex = webBlockLines.findIndex(
     (line) => line.trim() === "args:"
@@ -87,6 +88,34 @@ function extractComposeWebBuildArgs(): string {
     );
   }
   return sliceIndentedBlock(webBlockLines, argsLineIndex).join("\n");
+}
+
+function extractComposeServiceEnvironment(service: string): string {
+  const serviceBlockLines = extractComposeServiceBlock(service);
+  const environmentLineIndex = serviceBlockLines.findIndex(
+    (line) => line.trim() === "environment:"
+  );
+  if (environmentLineIndex === -1) {
+    throw new Error(
+      `Couldn't find \`${service}.environment:\` in docker-compose.app.yml`
+    );
+  }
+  return sliceIndentedBlock(serviceBlockLines, environmentLineIndex).join("\n");
+}
+
+function expectRequiredComposeVariable(block: string, name: string) {
+  const requiredExpansion = "${" + name + ":?";
+  expect(
+    block,
+    `docker-compose.app.yml must mark ${name} as required with Compose's :? expansion`
+  ).toContain(`${name}: ${requiredExpansion}`);
+}
+
+function expectComposeVariable(block: string, name: string, expansion: string) {
+  expect(
+    block,
+    `docker-compose.app.yml must wire ${name} to ${expansion}`
+  ).toContain(`${name}: ${expansion}`);
 }
 
 test("every NEXT_PUBLIC_* var declared in env.client.ts is wired through the Dockerfile's app-builder ARG/ENV pair", () => {
@@ -117,4 +146,45 @@ test("every NEXT_PUBLIC_* var declared in env.client.ts is passed as a build arg
       `docker-compose.app.yml's web.build.args is missing "${name}"`
     ).toMatch(new RegExp(`^\\s*${name}:`, "m"));
   }
+});
+
+test("Coolify compose keeps secrets required and derives safe service defaults", () => {
+  const baseUrlExpansion =
+    "${NEXT_PUBLIC_BASE_URL:-${SERVICE_URL_WEB:-http://localhost:4000}/api}";
+  const directUrlExpansion =
+    "${DIRECT_URL:-${DATABASE_URL:?Configure DATABASE_URL in Coolify}}";
+
+  const webBuildArgs = extractComposeWebBuildArgs();
+  for (const name of [
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  ]) {
+    expectRequiredComposeVariable(webBuildArgs, name);
+  }
+  expectComposeVariable(
+    webBuildArgs,
+    "NEXT_PUBLIC_BASE_URL",
+    baseUrlExpansion
+  );
+
+  const migrateEnvironment = extractComposeServiceEnvironment("migrate");
+  expectRequiredComposeVariable(migrateEnvironment, "DATABASE_URL");
+  expectComposeVariable(migrateEnvironment, "DIRECT_URL", directUrlExpansion);
+
+  const webEnvironment = extractComposeServiceEnvironment("web");
+  for (const name of [
+    "DATABASE_URL",
+    "JWT_SECRET",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  ]) {
+    expectRequiredComposeVariable(webEnvironment, name);
+  }
+  expectComposeVariable(webEnvironment, "DIRECT_URL", directUrlExpansion);
+  expectComposeVariable(
+    webEnvironment,
+    "NEXT_PUBLIC_BASE_URL",
+    baseUrlExpansion
+  );
 });


### PR DESCRIPTION
## Summary
- remove the runtime dependency on a repository `.env` file from the dev Compose configuration
- derive `NEXT_PUBLIC_BASE_URL` from Coolify's `SERVICE_URL_WEB`, appending `/api`, with `http://localhost:4000/api` as the local fallback
- let `DIRECT_URL` fall back to `DATABASE_URL` while preserving an explicit override for deployments that use separate pooled/direct connections
- keep database, JWT, Supabase service-role, and required public Supabase values fail-fast instead of assigning unsafe local/placeholder secrets
- keep optional Sentry/logging values defaulted as before
- add regression coverage for required values and the new Compose interpolation

## Auth/scopes
Fallstack currently authenticates through Supabase Auth and does not define ZITADEL scopes in its Compose/env configuration, so this PR intentionally does not add or alter auth scopes.

## Why
This aligns `dev` with the explicit deployment configuration already used on `main`, while making the public app URL derive automatically from Coolify and retaining useful local behavior.

`SERVICE_FQDN_WEB` is intentionally not consumed because the current Fallstack environment has no variable that needs a bare hostname; the relevant public app setting needs a complete URL.

## Validation
- added regression assertions for the exact `SERVICE_URL_WEB` and local fallback expansion
- added/retained assertions that required runtime/build values remain required
- Compose nested interpolation follows the supported `${VAR:-${OTHER:-default}}` form
