### PR TITLE
Resolve PR #321 configuration conflicts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,25 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
       day: monday
     groups:
       production-dependencies:
         dependency-type: production
+        update-types:
+          - minor
+          - patch
       development-dependencies:
         dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
     open-pull-requests-limit: 5
     commit-message:
       prefix: chore(deps)
@@ -19,6 +30,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
       day: monday
@@ -31,6 +43,7 @@ updates:
 
   - package-ecosystem: docker
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled, closed]
+
+jobs:
+  validate-release-label:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/release-policy@master
+        with:
+          github-token: ${{ github.token }}
+
+  publish-release:
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/release-publish@master
+        with:
+          github-token: ${{ github.token }}
+          product-name: Fallstack


### PR DESCRIPTION
Resolve the content conflicts preventing `dev` from merging cleanly into `main` in PR #321.

Changes:
- align `.github/dependabot.yml` with the current `main` policy, preserving `target-branch: dev` and semver-major ignores;
- add the repository-local `.github/workflows/release.yml` wrapper that invokes the organization-wide release actions from `Nucleo-Estudantes-Informatica-ISEP/.github`.

The more complete `dev` CI workflow is intentionally unchanged because it already contains the secret-scan addition present on `main`. Other files changed on `main` since the common ancestor are already identical between the two branches.