### PR TITLE
chore(ci): remove duplicate workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [dev, main]
-  push:
-    branches: [dev, main]
   workflow_dispatch:
 
 permissions:
@@ -98,9 +96,3 @@ jobs:
 
       - name: Verify application runs as non-root
         run: test "$(docker inspect --format '{{.Config.User}}' fallstack-app-check)" = "nextjs"
-
-  secret-scan:
-    name: Secret scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/secret-scan@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,25 @@ on:
     types: [opened, reopened, synchronize, labeled, unlabeled, closed]
 
 jobs:
-  release:
-    name: Release
+  validate-release-label:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/release-policy@master
+        with:
+          github-token: ${{ github.token }}
+
+  publish-release:
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
-    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/release.yml@master
-    with:
-      product_name: Fallstack
+    steps:
+      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/release-publish@master
+        with:
+          github-token: ${{ github.token }}
+          product-name: Fallstack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,25 +6,11 @@ on:
     types: [opened, reopened, synchronize, labeled, unlabeled, closed]
 
 jobs:
-  validate-release-label:
-    if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/release-policy@master
-        with:
-          github-token: ${{ github.token }}
-
-  publish-release:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+  release:
+    name: Release
     permissions:
       contents: write
       pull-requests: read
-    steps:
-      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/release-publish@master
-        with:
-          github-token: ${{ github.token }}
-          product-name: Fallstack
+    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/release.yml@master
+    with:
+      product_name: Fallstack

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,8 +6,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  security:
-    name: Security
+  dependency-review:
+    if: github.event_name == 'pull_request' && github.event.repository.private == false
+    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/dependency-review.yml@master
     permissions:
       contents: read
-    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/security.yml@master
+
+  secret-scan:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/secret-scan@master

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  dependency-review:
-    if: github.event_name == 'pull_request' && github.event.repository.private == false
-    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/dependency-review.yml@master
+  security:
+    name: Security
     permissions:
       contents: read
+    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/security.yml@master


### PR DESCRIPTION
## Summary

Normalize Fallstack against the organization workflow standard introduced in `Nucleo-Estudantes-Informatica-ISEP/.github#7` without changing the required status-check contexts enforced by the repository rulesets.

### CI
- keep Fallstack-specific test/typecheck/lint/build/Prisma/Docker jobs local
- remove the redundant full-CI `push` trigger for `dev`/`main`; the full quality suite now runs on PRs (or manually) instead of repeating after every merge
- remove `Secret scan` from the application CI workflow

### Security
- keep the existing protected `dependency-review / Dependency review` context
- move the organization-standard `Secret scan` into `security.yml`
- both checks still use the centralized `.github` reusable workflow/action implementations
- preserve the existing `Secret scan` status context so branch protection does not need to be weakened or rewritten

### Release
- keep the existing minimal caller around the centralized `release-policy` and `release-publish` actions
- preserve the protected `validate-release-label` context

## Intended result

- feature -> `dev` PR: Fallstack CI + dependency review + secret scan once
- merge -> `dev`: no second copy of the full quality suite
- `dev` -> `main` PR: Fallstack CI + security + release policy
- merge -> `main`: semantic release publication only

## Scope

No application/runtime code changes are included. This PR only changes GitHub Actions orchestration and deliberately preserves the required check names already used by the Fallstack rulesets.