### PR TITLE
release: promote dev to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,10 @@ NEXT_PUBLIC_SUPABASE_URL="http://127.0.0.1:54321"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="anon_key_here"
 SUPABASE_SERVICE_ROLE_KEY="service_role_key_here"
 
-# Tokens used by Fallstack features such as QR/action tokens.
-JWT_SECRET="super-secret-jwt-token-with-at-least-32-characters-long"
+# Local development secrets. Coolify generates these automatically when they
+# are left unset in deployed environments.
+JWT_SECRET="local-jwt-secret-change-me-32-characters"
+AUTH_SECRET="local-auth-secret-change-me-32-characters"
 
 # Direct AuthNEI / ZITADEL OIDC
 AUTH_ISSUER_URL="https://auth.nei-isep.org"
@@ -21,8 +23,10 @@ AUTH_PROJECT_ID="fallstack_project_id"
 AUTH_GLOBAL_PROJECT_ID="nei_global_project_id"
 AUTH_CLIENT_ID="fallstack_oidc_client_id"
 AUTH_CLIENT_SECRET="fallstack_oidc_client_secret"
-AUTH_SECRET="separate-fallstack-session-secret-at-least-32-characters"
-AUTH_SCOPES="openid email profile offline_access urn:zitadel:iam:org:projects:roles urn:zitadel:iam:org:project:id:nei_global_project_id:aud"
+# In Coolify, scopes and role-claim names are derived from the project IDs when
+# left unset. The Fallstack project audience exposes `employee`; the global
+# project audience exposes the shared `admin` role.
+AUTH_SCOPES="openid email profile urn:zitadel:iam:org:projects:roles urn:zitadel:iam:org:project:id:fallstack_project_id:aud urn:zitadel:iam:org:project:id:nei_global_project_id:aud"
 AUTH_ROLE_CLAIM="urn:zitadel:iam:org:project:fallstack_project_id:roles"
 AUTH_GLOBAL_ROLE_CLAIM="urn:zitadel:iam:org:project:nei_global_project_id:roles"
 # In Coolify these two derive automatically from SERVICE_URL_WEB when unset.

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-# Public API base. In Coolify/docker-compose this is derived from
-# SERVICE_URL_WEB + /api when left unset.
-NEXT_PUBLIC_BASE_URL="http://localhost:4000/api"
+# Public API base for native development. In Coolify/docker-compose this is
+# derived from SERVICE_URL_WEB + /api when left unset.
+NEXT_PUBLIC_BASE_URL="http://localhost:3000/api"
 
 # Postgres
 DATABASE_URL="postgresql://postgres:postgres@localhost:54322/postgres"
@@ -29,9 +29,10 @@ AUTH_CLIENT_SECRET="fallstack_oidc_client_secret"
 AUTH_SCOPES="openid email profile urn:zitadel:iam:org:projects:roles urn:zitadel:iam:org:project:id:fallstack_project_id:aud urn:zitadel:iam:org:project:id:nei_global_project_id:aud"
 AUTH_ROLE_CLAIM="urn:zitadel:iam:org:project:fallstack_project_id:roles"
 AUTH_GLOBAL_ROLE_CLAIM="urn:zitadel:iam:org:project:nei_global_project_id:roles"
-# In Coolify these two derive automatically from SERVICE_URL_WEB when unset.
-AUTH_REDIRECT_URI="http://localhost:4000/api/auth/callback/zitadel"
-AUTH_POST_LOGOUT_REDIRECT_URI="http://localhost:4000"
+# Native pnpm dev runs on port 3000. In Coolify these two derive automatically
+# from SERVICE_URL_WEB when unset.
+AUTH_REDIRECT_URI="http://localhost:3000/api/auth/callback/zitadel"
+AUTH_POST_LOGOUT_REDIRECT_URI="http://localhost:3000"
 ZITADEL_ORG_ID="nei_org_id"
 ZITADEL_ROLE_ASSIGNER_TOKEN="fallstack_role_assigner_pat"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ ARG SENTRY_PROJECT=""
 # env_file (see docker-compose.app.yml).
 ARG NEXT_PUBLIC_SUPABASE_URL=""
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY=""
-ARG NEXT_PUBLIC_BASE_URL=""
+ARG NEXT_PUBLIC_BASE_URL="http://localhost:4000/api"
 # Links the admin backoffice's Logs nav item out to GlitchTip/Sentry -
 # NEXT_PUBLIC_*, so (like the others above) it must be supplied as a build
 # arg to actually land in the compiled bundle; declaring it only in

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -30,14 +30,10 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
-    ports:
-      - "4000:4000"
     environment:
-      PORT: 4000
-      HOSTNAME: 0.0.0.0
       DATABASE_URL: ${DATABASE_URL:?Configure DATABASE_URL in Coolify}
       DIRECT_URL: ${DIRECT_URL:-${DATABASE_URL:?Configure DATABASE_URL in Coolify}}
-      JWT_SECRET: ${JWT_SECRET:?Configure JWT_SECRET in Coolify}
+      JWT_SECRET: ${JWT_SECRET:-${SERVICE_REALBASE64_64_JWT}}
 
       # Supabase is retained for Storage/Postgres only; GoTrue is no longer in
       # the Fallstack authentication path.
@@ -45,16 +41,18 @@ services:
       NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL:?Configure NEXT_PUBLIC_SUPABASE_URL in Coolify}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:?Configure NEXT_PUBLIC_SUPABASE_ANON_KEY in Coolify}
 
-      # Direct AuthNEI/ZITADEL OIDC.
-      AUTH_ISSUER_URL: ${AUTH_ISSUER_URL:?Configure AUTH_ISSUER_URL in Coolify}
+      # Direct AuthNEI/ZITADEL OIDC. Only values that identify this concrete
+      # ZITADEL application/organization need to be configured in Coolify;
+      # stable URLs, generated secrets, scopes and claim names are derived.
+      AUTH_ISSUER_URL: ${AUTH_ISSUER_URL:-https://auth.nei-isep.org}
       AUTH_PROJECT_ID: ${AUTH_PROJECT_ID:?Configure AUTH_PROJECT_ID in Coolify}
       AUTH_GLOBAL_PROJECT_ID: ${AUTH_GLOBAL_PROJECT_ID:?Configure AUTH_GLOBAL_PROJECT_ID in Coolify}
       AUTH_CLIENT_ID: ${AUTH_CLIENT_ID:?Configure AUTH_CLIENT_ID in Coolify}
       AUTH_CLIENT_SECRET: ${AUTH_CLIENT_SECRET:?Configure AUTH_CLIENT_SECRET in Coolify}
-      AUTH_SECRET: ${AUTH_SECRET:?Configure AUTH_SECRET in Coolify}
-      AUTH_SCOPES: ${AUTH_SCOPES:?Configure AUTH_SCOPES in Coolify}
-      AUTH_ROLE_CLAIM: ${AUTH_ROLE_CLAIM:?Configure AUTH_ROLE_CLAIM in Coolify}
-      AUTH_GLOBAL_ROLE_CLAIM: ${AUTH_GLOBAL_ROLE_CLAIM:?Configure AUTH_GLOBAL_ROLE_CLAIM in Coolify}
+      AUTH_SECRET: ${AUTH_SECRET:-${SERVICE_REALBASE64_64_AUTH}}
+      AUTH_SCOPES: ${AUTH_SCOPES:-openid email profile urn:zitadel:iam:org:projects:roles urn:zitadel:iam:org:project:id:${AUTH_PROJECT_ID}:aud urn:zitadel:iam:org:project:id:${AUTH_GLOBAL_PROJECT_ID}:aud}
+      AUTH_ROLE_CLAIM: ${AUTH_ROLE_CLAIM:-urn:zitadel:iam:org:project:${AUTH_PROJECT_ID}:roles}
+      AUTH_GLOBAL_ROLE_CLAIM: ${AUTH_GLOBAL_ROLE_CLAIM:-urn:zitadel:iam:org:project:${AUTH_GLOBAL_PROJECT_ID}:roles}
       AUTH_REDIRECT_URI: ${AUTH_REDIRECT_URI:-${SERVICE_URL_WEB:-http://localhost:4000}/api/auth/callback/zitadel}
       AUTH_POST_LOGOUT_REDIRECT_URI: ${AUTH_POST_LOGOUT_REDIRECT_URI:-${SERVICE_URL_WEB:-http://localhost:4000}}
       ZITADEL_ORG_ID: ${ZITADEL_ORG_ID:?Configure ZITADEL_ORG_ID in Coolify}

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -4,8 +4,8 @@ services:
       context: .
       dockerfile: Dockerfile
       target: migrator
-    container_name: fallstack-migrate
     restart: "no"
+    exclude_from_hc: true
     environment:
       DATABASE_URL: ${DATABASE_URL:?Configure DATABASE_URL in Coolify}
       DIRECT_URL: ${DIRECT_URL:-${DATABASE_URL:?Configure DATABASE_URL in Coolify}}
@@ -25,7 +25,6 @@ services:
         NEXT_PUBLIC_LOGS_DASHBOARD_URL: ${NEXT_PUBLIC_LOGS_DASHBOARD_URL:-}
       secrets:
         - sentry_auth_token
-    container_name: fallstack-app
     restart: unless-stopped
     depends_on:
       migrate:

--- a/src/config/env.client.test.ts
+++ b/src/config/env.client.test.ts
@@ -11,14 +11,14 @@ afterEach(() => {
   process.env = { ...ORIGINAL_ENV };
 });
 
-test("falls back to the default NEXT_PUBLIC_BASE_URL when the Dockerfile's empty-string ARG default is passed through", async () => {
+test("falls back to the Docker port when NEXT_PUBLIC_BASE_URL is empty", async () => {
   process.env.NEXT_PUBLIC_SUPABASE_URL = "https://project.supabase.co";
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
   process.env.NEXT_PUBLIC_BASE_URL = "";
 
   const { clientEnv } = await import("./env.client");
 
-  expect(clientEnv.NEXT_PUBLIC_BASE_URL).toBe("http://localhost:3000/api");
+  expect(clientEnv.NEXT_PUBLIC_BASE_URL).toBe("http://localhost:4000/api");
 });
 
 test("still requires a real NEXT_PUBLIC_SUPABASE_URL (no default)", async () => {

--- a/src/config/env.client.test.ts
+++ b/src/config/env.client.test.ts
@@ -11,14 +11,14 @@ afterEach(() => {
   process.env = { ...ORIGINAL_ENV };
 });
 
-test("falls back to the Docker port when NEXT_PUBLIC_BASE_URL is empty", async () => {
+test("falls back to the native Next dev port when NEXT_PUBLIC_BASE_URL is empty", async () => {
   process.env.NEXT_PUBLIC_SUPABASE_URL = "https://project.supabase.co";
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
   process.env.NEXT_PUBLIC_BASE_URL = "";
 
   const { clientEnv } = await import("./env.client");
 
-  expect(clientEnv.NEXT_PUBLIC_BASE_URL).toBe("http://localhost:4000/api");
+  expect(clientEnv.NEXT_PUBLIC_BASE_URL).toBe("http://localhost:3000/api");
 });
 
 test("still requires a real NEXT_PUBLIC_SUPABASE_URL (no default)", async () => {

--- a/src/config/env.client.ts
+++ b/src/config/env.client.ts
@@ -6,17 +6,11 @@ import { z } from "zod";
 const clientEnvSchema = z.object({
   NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
-  // Environment-related fix, not strictly in scope of the Docker non-root
-  // change this shipped alongside (#218/#207): the Dockerfile's
-  // `ARG NEXT_PUBLIC_BASE_URL=""` default means "unset" the same way
-  // `NEXT_PUBLIC_SENTRY_DSN` below does, but without this preprocess step
-  // the empty string reached `.url()` directly and failed validation
-  // instead of falling through to `.default()` — so a build run without
-  // this build arg supplied (e.g. `docker build` with no `--build-arg`s)
-  // failed at `next build` time instead of using the documented default.
+  // Explicit empty values still mean "unset" so direct builds can fall back
+  // to the same local port used by the Docker runner and .env.example.
   NEXT_PUBLIC_BASE_URL: z.preprocess(
     (value) => (value === "" ? undefined : value),
-    z.string().url().default("http://localhost:3000/api")
+    z.string().url().default("http://localhost:4000/api")
   ),
   // Empty string (the Dockerfile's `ARG NEXT_PUBLIC_SENTRY_DSN=""` default
   // when no build arg is supplied) means "unset", same as undefined — not

--- a/src/config/env.client.ts
+++ b/src/config/env.client.ts
@@ -6,11 +6,11 @@ import { z } from "zod";
 const clientEnvSchema = z.object({
   NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
-  // Explicit empty values still mean "unset" so direct builds can fall back
-  // to the same local port used by the Docker runner and .env.example.
+  // Explicit empty values still mean "unset". Native `pnpm dev` uses Next's
+  // default port 3000; Docker/Compose inject their own port-4000 public URL.
   NEXT_PUBLIC_BASE_URL: z.preprocess(
     (value) => (value === "" ? undefined : value),
-    z.string().url().default("http://localhost:4000/api")
+    z.string().url().default("http://localhost:3000/api")
   ),
   // Empty string (the Dockerfile's `ARG NEXT_PUBLIC_SENTRY_DSN=""` default
   // when no build arg is supplied) means "unset", same as undefined — not

--- a/tests/e2e/dockerBuildArgs.test.ts
+++ b/tests/e2e/dockerBuildArgs.test.ts
@@ -193,3 +193,13 @@ test("Coolify compose keeps secrets required and derives safe service defaults",
     "${AUTH_SECRET:-${SERVICE_REALBASE64_64_AUTH}}"
   );
 });
+
+test("Coolify compose keeps the migrator one-shot and avoids global container names", () => {
+  const migrateBlock = extractComposeServiceBlock("migrate").join("\n");
+  const webBlock = extractComposeServiceBlock("web").join("\n");
+
+  expect(migrateBlock).toContain('restart: "no"');
+  expect(migrateBlock).toContain("exclude_from_hc: true");
+  expect(migrateBlock).not.toMatch(/^\s*container_name:/m);
+  expect(webBlock).not.toMatch(/^\s*container_name:/m);
+});

--- a/tests/e2e/dockerBuildArgs.test.ts
+++ b/tests/e2e/dockerBuildArgs.test.ts
@@ -161,11 +161,7 @@ test("Coolify compose keeps secrets required and derives safe service defaults",
   ]) {
     expectRequiredComposeVariable(webBuildArgs, name);
   }
-  expectComposeVariable(
-    webBuildArgs,
-    "NEXT_PUBLIC_BASE_URL",
-    baseUrlExpansion
-  );
+  expectComposeVariable(webBuildArgs, "NEXT_PUBLIC_BASE_URL", baseUrlExpansion);
 
   const migrateEnvironment = extractComposeServiceEnvironment("migrate");
   expectRequiredComposeVariable(migrateEnvironment, "DATABASE_URL");
@@ -174,7 +170,6 @@ test("Coolify compose keeps secrets required and derives safe service defaults",
   const webEnvironment = extractComposeServiceEnvironment("web");
   for (const name of [
     "DATABASE_URL",
-    "JWT_SECRET",
     "SUPABASE_SERVICE_ROLE_KEY",
     "NEXT_PUBLIC_SUPABASE_URL",
     "NEXT_PUBLIC_SUPABASE_ANON_KEY",
@@ -186,5 +181,15 @@ test("Coolify compose keeps secrets required and derives safe service defaults",
     webEnvironment,
     "NEXT_PUBLIC_BASE_URL",
     baseUrlExpansion
+  );
+  expectComposeVariable(
+    webEnvironment,
+    "JWT_SECRET",
+    "${JWT_SECRET:-${SERVICE_REALBASE64_64_JWT}}"
+  );
+  expectComposeVariable(
+    webEnvironment,
+    "AUTH_SECRET",
+    "${AUTH_SECRET:-${SERVICE_REALBASE64_64_AUTH}}"
   );
 });


### PR DESCRIPTION
## Summary

Promote the current `dev` branch to `main` after the Fallstack Coolify environment cleanup and deployment fixes passed CI and Security on the source PR.

Includes:
- simplified Coolify env defaults and generated secrets
- corrected native development URL fallback
- one-shot migrator configuration for Coolify
- removal of fixed Compose container names
- associated deployment/config tests