### PR TITLE
chore(ci): restore edition label in release titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,17 @@ jobs:
       contents: write
       pull-requests: read
     steps:
+      - name: Checkout merged commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Compute edition label
+        id: edition
+        run: echo "label=$(grep -oP '(?<=year: )\d+' src/edition/branding.ts) Edition" >> "$GITHUB_OUTPUT"
+
       - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/release-publish@master
         with:
           github-token: ${{ github.token }}
           product-name: Fallstack
+          edition-label: ${{ steps.edition.outputs.label }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Compute edition label
         id: edition
-        run: echo "label=$(grep -oP '(?<=year: )\d+' src/edition/branding.ts) Edition" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "label=$(grep -oP '(?<=year: )\d+' src/edition/branding.ts) Edition" >> "$GITHUB_OUTPUT"
 
       - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/release-publish@master
         with:


### PR DESCRIPTION
## Summary

- Restores the pre-automation "Fallstack 2026 Edition — vX.Y.Z" release title format, this time generated automatically instead of by hand.
- Reads `src/edition/branding.ts`'s `year` field at release time and passes it as the new `edition-label` input to the org's shared `release-publish` action (see Nucleo-Estudantes-Informatica-ISEP/.github#10), which composes the title as `<product-name> <edition-label> — <tag>` when set.
- The underlying semver scheme is unchanged (still climbs forever: v2.x, v3.x, ...) — only the release title gains the edition context back. No per-edition version reset, no CHANGELOG.md changes.
- This is not fallstack-specific: the shared action's `edition-label` input is a plain opt-in string, so any repo can wire it up against its own edition/config source the same way.

## Validation

- [x] Verified the extraction regex against the current `src/edition/branding.ts` locally: `grep -oP '(?<=year: )\d+' src/edition/branding.ts` → `2026`.
- [ ] CI checks pass (verifying live on this PR).
- [ ] The next real release merge shows the edition label in its title (can't fully verify without a merge to main).

## Release impact

- [x] Exempt — Dependabot or documentation/CI/metadata-only change

## Deployment / migration notes

None.

## Manual actions

None.

## Issues

Refs Nucleo-Estudantes-Informatica-ISEP/.github#10