### PR TITLE
fix: attach web/migrate to external Supabase network

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -9,6 +9,9 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL:?Configure DATABASE_URL in Coolify}
       DIRECT_URL: ${DIRECT_URL:-${DATABASE_URL:?Configure DATABASE_URL in Coolify}}
+    networks:
+      - default
+      - supabase_stack
 
   web:
     build:
@@ -61,7 +64,15 @@ services:
       NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
       NEXT_PUBLIC_LOGS_DASHBOARD_URL: ${NEXT_PUBLIC_LOGS_DASHBOARD_URL:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
+    networks:
+      - default
+      - supabase_stack
 
 secrets:
   sentry_auth_token:
     environment: SENTRY_AUTH_TOKEN
+
+networks:
+  supabase_stack:
+    external: true
+    name: ${SUPABASE_NETWORK_NAME}


### PR DESCRIPTION
## Summary
- Attach `web` and `migrate` to an external `supabase_stack` Docker network, in addition to the default Compose network
- Reference the network by name via `${SUPABASE_NETWORK_NAME}` instead of a hardcoded UUID, since `docker-compose.app.yml` is shared unmodified across dev/staging/production and each environment has its own separate Supabase Docker network

## Test plan
- [x] `docker compose -f docker-compose.app.yml config` validates and correctly resolves the external network name from `SUPABASE_NETWORK_NAME`
- [x] `pnpm test`, `pnpm typecheck`, `pnpm lint` all pass
- [ ] Set `SUPABASE_NETWORK_NAME` in Coolify for each environment and confirm `web`/`migrate` can reach Supabase after deploy