### PR TITLE
release: promote dev to main

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -9,6 +9,9 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL:?Configure DATABASE_URL in Coolify}
       DIRECT_URL: ${DIRECT_URL:-${DATABASE_URL:?Configure DATABASE_URL in Coolify}}
+    networks:
+      - default
+      - supabase_stack
 
   web:
     build:
@@ -61,7 +64,15 @@ services:
       NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
       NEXT_PUBLIC_LOGS_DASHBOARD_URL: ${NEXT_PUBLIC_LOGS_DASHBOARD_URL:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
+    networks:
+      - default
+      - supabase_stack
 
 secrets:
   sentry_auth_token:
     environment: SENTRY_AUTH_TOKEN
+
+networks:
+  supabase_stack:
+    external: true
+    name: ${SUPABASE_NETWORK_NAME}


### PR DESCRIPTION
## Summary
- Attach `web`/`migrate` to the external Supabase Docker network via `SUPABASE_NETWORK_NAME` instead of a hardcoded network UUID, so the app can reach Postgres over the internal network instead of an exposed port in production.

## Test plan
- [ ] CI checks pass (lint, typecheck, tests, build, Prisma validate, Docker builds, Gitleaks)