### PR TITLE
chore(ci): restore edition label in release titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,17 @@ jobs:
       contents: write
       pull-requests: read
     steps:
+      - name: Checkout merged commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Compute edition label
+        id: edition
+        run: echo "label=$(grep -oP '(?<=year: )\d+' src/edition/branding.ts) Edition" >> "$GITHUB_OUTPUT"
+
       - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/release-publish@master
         with:
           github-token: ${{ github.token }}
           product-name: Fallstack
+          edition-label: ${{ steps.edition.outputs.label }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Compute edition label
         id: edition
-        run: echo "label=$(grep -oP '(?<=year: )\d+' src/edition/branding.ts) Edition" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "label=$(grep -oP '(?<=year: )\d+' src/edition/branding.ts) Edition" >> "$GITHUB_OUTPUT"
 
       - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/release-publish@master
         with:


### PR DESCRIPTION
## Summary
- Same change as #331, targeted directly at `main` as a one-off exception rather than waiting for the next `dev` -> `main` release promotion.
- Adds the "Compute edition label" step to `release.yml`'s `publish-release` job so release titles include the edition label again (e.g. "2026 Edition").
- Includes the YAML fix already applied on #331: the `run:` step uses a block scalar (`run: |`) so the `: ` inside the `(?<=year: )` regex lookbehind isn't misparsed as a YAML mapping separator (`actionlint`/`yaml.safe_load` failed on the plain-scalar form).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` -> valid
- [x] `pnpm test` -> 283/283 passing
- [x] Confirmed the extracted regex against `src/edition/branding.ts` (`year: 2026`) resolves to `2026`