### PR TITLE
fix: migrate server-only Supabase credential configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ DIRECT_URL=""
 # Supabase is used for Storage (and the Postgres DB above), NOT authentication.
 NEXT_PUBLIC_SUPABASE_URL="http://127.0.0.1:54321"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="anon_key_here"
-SUPABASE_SERVICE_ROLE_KEY="service_role_key_here"
+SUPABASE_SECRET_KEY="service_role_key_here"
 
 # Local development secrets. Coolify generates these automatically when they
 # are left unset in deployed environments.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   DIRECT_URL: postgresql://postgres:postgres@localhost:5432/ci
   NEXT_PUBLIC_SUPABASE_URL: https://ci-placeholder.supabase.co
   NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder
-  SUPABASE_SERVICE_ROLE_KEY: ${{ github.sha }}
+  SUPABASE_SECRET_KEY: ${{ github.sha }}
   NEXT_PUBLIC_BASE_URL: https://ci.invalid/api
   JWT_SECRET: ${{ github.sha }}
   AUTH_ISSUER_URL: https://auth.ci.invalid

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,20 +2,19 @@ name: Security
 
 on:
   pull_request:
-    branches: [dev, main]
   workflow_dispatch:
+    inputs:
+      full_history:
+        description: Scan all reachable history instead of the latest change.
+        required: false
+        type: boolean
+        default: true
 
 jobs:
-  dependency-review:
-    if: github.event_name == 'pull_request' && github.event.repository.private == false
-    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/dependency-review.yml@master
+  security:
+    name: Security
     permissions:
       contents: read
-
-  secret-scan:
-    name: Secret scan
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/secret-scan@master
+    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/security.yml@master
+    with:
+      full_history: ${{ github.event_name == 'workflow_dispatch' && inputs.full_history || false }}

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ next-env.d.ts
 certificates
 
 prisma/seed.prod.ts
+
+# Local environment files (NEI)
+.env*
+!.env.example
+!**/.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ ARG SENTRY_ORG=""
 ARG SENTRY_PROJECT=""
 # Public (non-secret) Supabase values: Next.js inlines these into the
 # browser bundle at build time, so the builder stage needs them directly —
-# unlike JWT_SECRET/SUPABASE_SERVICE_ROLE_KEY, which stay runtime-only via
+# unlike JWT_SECRET/SUPABASE_SECRET_KEY, which stay runtime-only via
 # env_file (see docker-compose.app.yml).
 ARG NEXT_PUBLIC_SUPABASE_URL=""
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY=""

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cp .env.example .env
 - `DIRECT_URL`
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-- `SUPABASE_SERVICE_ROLE_KEY` (service role)
+- `SUPABASE_SECRET_KEY` (service role)
 - `JWT_SECRET`
 
 Defaulted (override only if you need something other than local dev defaults):

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -39,7 +39,7 @@ services:
 
       # Supabase is retained for Storage/Postgres only; GoTrue is no longer in
       # the Fallstack authentication path.
-      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:?Configure SUPABASE_SERVICE_ROLE_KEY in Coolify}
+      SUPABASE_SECRET_KEY: ${SUPABASE_SECRET_KEY:?Configure SUPABASE_SECRET_KEY in Coolify}
       NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL:?Configure NEXT_PUBLIC_SUPABASE_URL in Coolify}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:?Configure NEXT_PUBLIC_SUPABASE_ANON_KEY in Coolify}
 

--- a/src/app/api/actions/[id]/route.test.ts
+++ b/src/app/api/actions/[id]/route.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/application/services/actionService", () => ({
 
 beforeAll(() => {
   vi.stubEnv("JWT_SECRET", "test-only-secret-at-least-32-characters-long");
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/app/api/admin/faqs/[id]/route.test.ts
+++ b/src/app/api/admin/faqs/[id]/route.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/application/services/faqService", () => ({
 }));
 
 beforeAll(() => {
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/app/api/admin/faqs/order/route.test.ts
+++ b/src/app/api/admin/faqs/order/route.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/application/services/faqService", () => ({
 }));
 
 beforeAll(() => {
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/app/api/admin/faqs/route.test.ts
+++ b/src/app/api/admin/faqs/route.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/application/services/faqService", () => ({
 }));
 
 beforeAll(() => {
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/app/api/admin/schedule/[id]/route.test.ts
+++ b/src/app/api/admin/schedule/[id]/route.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/application/services/scheduleService", () => ({
 }));
 
 beforeAll(() => {
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/app/api/admin/schedule/order/route.test.ts
+++ b/src/app/api/admin/schedule/order/route.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/application/services/scheduleService", () => ({
 }));
 
 beforeAll(() => {
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/app/api/admin/schedule/route.test.ts
+++ b/src/app/api/admin/schedule/route.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/application/services/scheduleService", () => ({
 }));
 
 beforeAll(() => {
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/app/api/faqs/route.test.ts
+++ b/src/app/api/faqs/route.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/application/services/faqService", () => ({
 }));
 
 beforeAll(() => {
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/app/api/qrcode/route.test.ts
+++ b/src/app/api/qrcode/route.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/application/services/sessionService", () => ({
 
 beforeAll(() => {
   vi.stubEnv("JWT_SECRET", "test-only-secret-at-least-32-characters-long");
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/app/api/schedule/route.test.ts
+++ b/src/app/api/schedule/route.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/application/services/scheduleService", () => ({
 }));
 
 beforeAll(() => {
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/application/services/authService.test.ts
+++ b/src/application/services/authService.test.ts
@@ -11,7 +11,7 @@ vi.mock("next/headers", () => ({ cookies: vi.fn() }));
 // leak into other test files sharing the same worker.
 beforeAll(() => {
   vi.stubEnv("JWT_SECRET", "test-only-secret-at-least-32-characters-long");
-  vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+  vi.stubEnv("SUPABASE_SECRET_KEY", "test-secret-key");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 });

--- a/src/config/env.server.ts
+++ b/src/config/env.server.ts
@@ -11,7 +11,7 @@ const serverEnvSchema = z.object({
   JWT_SECRET: z
     .string()
     .min(32, "JWT_SECRET must be at least 32 characters long"),
-  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  SUPABASE_SECRET_KEY: z.string().min(1),
   NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
 

--- a/src/schemas/logoSchema.test.ts
+++ b/src/schemas/logoSchema.test.ts
@@ -7,7 +7,7 @@ vi.mock("server-only", () => ({}));
 // values - CI runs `pnpm test` with no .env file at all.
 vi.stubEnv("NODE_ENV", "test");
 vi.stubEnv("JWT_SECRET", "a".repeat(32));
-vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+vi.stubEnv("SUPABASE_SECRET_KEY", "service-role-key");
 vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
 vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon-key");
 

--- a/src/utils/supabase/admin.ts
+++ b/src/utils/supabase/admin.ts
@@ -6,7 +6,7 @@ import { createClient } from "@supabase/supabase-js";
 export function createAdminClient() {
   return createClient(
     serverEnv.NEXT_PUBLIC_SUPABASE_URL,
-    serverEnv.SUPABASE_SERVICE_ROLE_KEY,
+    serverEnv.SUPABASE_SECRET_KEY,
     {
       auth: { persistSession: false },
     }

--- a/tests/e2e/dockerBuildArgs.test.ts
+++ b/tests/e2e/dockerBuildArgs.test.ts
@@ -170,7 +170,7 @@ test("Coolify compose keeps secrets required and derives safe service defaults",
   const webEnvironment = extractComposeServiceEnvironment("web");
   for (const name of [
     "DATABASE_URL",
-    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPABASE_SECRET_KEY",
     "NEXT_PUBLIC_SUPABASE_URL",
     "NEXT_PUBLIC_SUPABASE_ANON_KEY",
   ]) {


### PR DESCRIPTION
## Summary

Rename SUPABASE_SERVICE_ROLE_KEY to SUPABASE_SECRET_KEY across server validation, Compose, tests and documentation. No credential values are added.

Use the canonical reusable Security workflow with an explicit manual full-history input. Ignore operational `.env*` files while permitting reviewed `.env.example` placeholders.

## Validation

- [x] Workflow syntax and staged redacted secret scan passed
- [ ] Hosted required checks and maintainer review complete

Frozen install, lint, 297 tests and typecheck passed locally. Production build status is recorded in the audit handoff and CI; provider smoke tests remain pending.

## Release impact

Security/configuration fix; coordinate deployment as below.

## Deployment / migration notes

Before deploying this change, provision a replacement Supabase secret key and set SUPABASE_SECRET_KEY in the deployment secret store. Test all server-side Storage/admin paths. Migrate every other legacy-key consumer before disabling the old key.

## Manual actions

Provider login/rotation and production verification are not performed by this PR. Review retained provider logs and record unavailable retention. Do not resolve secret alerts as revoked until provider-side revocation and old-credential rejection are proven. Historical findings remain pending that evidence; no history rewrite or scan bypass is included.

## Issues

No incident is closed by this code-only PR.
