### PR TITLE
chore: align CI and supported runtime on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20.19.1
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint": "^9.39.5",
     "eslint-config-next": "^15.5.24",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-import-helpers": "^0.2.0",
+    "eslint-plugin-import-helpers": "^2.0.2",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-tailwindcss": "4.4.0",
     "globals": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "dev": "next dev",
@@ -82,7 +82,7 @@
     "eslint": "^9.39.5",
     "eslint-config-next": "^15.5.24",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-import-helpers": "^2.0.2",
+    "eslint-plugin-import-helpers": "^0.2.0",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-tailwindcss": "4.4.0",
     "globals": "^16.5.0",


### PR DESCRIPTION
## Summary

- run the CI quality job on Node 24 instead of Node 20.19.1
- raise the declared minimum Node version from `>=20.9.0` to `>=24.0.0`
- keep CI aligned with the existing Node 24 production Docker image and `@types/node` 24

## Rationale

The production Docker image already builds and runs on Node 24, while the quality CI job still used Node 20.19.1. Node 20 is end-of-life, so keeping the quality checks on it creates an unnecessary runtime mismatch and can make local/CI build comparisons misleading.

## Scope

Only `.github/workflows/ci.yml` and `package.json` are changed. No application code or dependency versions are modified.